### PR TITLE
Add check for open IAM roles

### DIFF
--- a/collect.js
+++ b/collect.js
@@ -223,6 +223,10 @@ var calls = {
 		listUsers: {
 			property: 'Users'
 		},
+		listRoles: {
+			property: 'Roles',
+			override: true
+		},
 		getAccountPasswordPolicy: {
 			property: 'PasswordPolicy'
 		},

--- a/collectors/iam/listRoles.js
+++ b/collectors/iam/listRoles.js
@@ -1,0 +1,22 @@
+var AWS = require('aws-sdk');
+var async = require('async');
+
+module.exports = function(AWSConfig, collection, callback) {
+	var iam = new AWS.IAM(AWSConfig);
+
+	var Marker;
+	async.doWhilst(function(pageCb) {
+		iam.listRoles({
+			Marker
+		}, function(err, data) {
+			if(err) {
+				collection.iam.listRoles[AWSCONFIG.region].err = err;
+			}
+
+			if (!collection.iam.listRoles[AWSConfig.region].data) collection.iam.listRoles[AWSConfig.region].data = [];
+			collection.iam.listRoles[AWSConfig.region].data = collection.iam.listRoles[AWSConfig.region].data.concat(data.Roles);
+			Marker = data.Marker;
+			pageCb();
+		});
+	}, function() { return Marker !== undefined }, callback);
+};

--- a/exports.js
+++ b/exports.js
@@ -71,6 +71,7 @@ module.exports = {
     'maxPasswordAge'                : require(__dirname + '/plugins/iam/maxPasswordAge.js'),
     'minPasswordLength'             : require(__dirname + '/plugins/iam/minPasswordLength.js'),
     'noUserIamPolicies'             : require(__dirname + '/plugins/iam/noUserIamPolicies.js'),
+    'openIamRoles'                  : require(__dirname + '/plugins/iam/openIamRoles.js'),
     'passwordExpiration'            : require(__dirname + '/plugins/iam/passwordExpiration.js'),
     'passwordRequiresLowercase'     : require(__dirname + '/plugins/iam/passwordRequiresLowercase.js'),
     'passwordRequiresNumbers'       : require(__dirname + '/plugins/iam/passwordRequiresNumbers.js'),

--- a/plugins/iam/openIamRoles.js
+++ b/plugins/iam/openIamRoles.js
@@ -1,0 +1,55 @@
+var async = require('async');
+var helpers = require('../../helpers');
+
+module.exports = {
+	title: 'Open IAM Roles',
+	category: 'IAM',
+	description: 'Ensures IAM role trust policies do not allow everyone to assume the role',
+	more_info: 'IAM role trust policies should trust specific AWS services, users, roles, identity providers, or accounts. Trusting `*` allows any AWS user to discover and assume that role.',
+	link: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html',
+	recommended_action: 'Limit the trust policy statements on the role such that only desired users, roles, identity providers, or AWS accounts can assume the role',
+	apis: ['IAM:listRoles'],
+
+	run: function(cache, settings, callback) {
+		var results = [];
+		var source = {};
+		
+		var region = settings.govcloud ? 'us-gov-west-1' : 'us-east-1';
+		var listRoles = helpers.addSource(cache, source,
+				['iam', 'listRoles', region]);
+
+		if (!listRoles) return callback(null, results, source);
+
+		if (listRoles.err || !listRoles.data) {
+			helpers.addResult(results, 3,
+				'Unable to query for IAM role status: ' + helpers.addError(listRoles));
+			return callback(null, results, source);
+		}
+
+		if (!listRoles.data.length) {
+			helpers.addResult(results, 0, 'No IAM roles found');
+			return callback(null, results, source);
+		}
+
+		async.each(listRoles.data, function(role, cb){
+			if(!role.AssumeRolePolicyDocument) return cb();
+
+			var trustPolicy = JSON.parse(decodeURIComponent(role.AssumeRolePolicyDocument));
+			for (let statement of trustPolicy.Statement) {
+				if (statement.Effect !== 'Allow' || !statement.Principal.AWS) continue;
+
+				if (!Array.isArray(statement.Principal.AWS)) {
+					statement.Principal.AWS = [statement.Principal.AWS];
+				}
+
+				if (statement.Principal.AWS.includes('*')) {
+					helpers.addResult(results, 2, 'Role trust policy allows any AWS user to assume', 'global', role.Arn);
+				}
+			}
+
+			cb();
+		}, function(){
+			callback(null, results, source);
+		});
+	}
+};


### PR DESCRIPTION
Check IAM roles for AssumeRolePolicies that allow any AWS users to
assume the role. Checks for principal `AWS: *` in trust policy
statements.

---

I was reading https://rhinosecuritylabs.com/aws/assume-worst-aws-assume-role-enumeration/ a few days ago. I hadn't considered that an IAM administrator might misconfigure an AssumeRolePolicy to allow any AWS user to assume a role, but it seems like a serious issue that CloudSploit should have a check for.