### PR TITLE
Fixing gcp json parsing for #269

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,7 @@ if (config.credentials.aws.credential_file) {
 } else if (config.credentials.google.credential_file) {
     settings.cloud = 'google';
     cloudConfig = loadHelperFile(config.credentials.google.credential_file);
+    cloudConfig.project = cloudConfig.project_id;
 } else if (config.credentials.google.project) {
     settings.cloud = 'google';
     checkRequiredKeys(config.credentials.google, ['client_email', 'private_key']);


### PR DESCRIPTION
This should solve #269 by copying the `project_id` variable (which Google writes to the .json file) to `project`, which cloudsploit expects.