### PR TITLE
Bugfix/engine.js: check if plugin results is null

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -100,7 +100,7 @@ var engine = function(cloudConfig, settings) {
     }, function(err, collection) {
         if (err || !collection || !Object.keys(collection).length) return console.log(`ERROR: Unable to obtain API metadata: ${err || 'No data returned'}`);
         outputHandler.writeCollection(collection, settings.cloud);
-        
+
         console.log('INFO: Metadata collection complete. Analyzing...');
         console.log('INFO: Analysis complete. Scan report to follow...');
 
@@ -110,13 +110,14 @@ var engine = function(cloudConfig, settings) {
             if (skippedPlugins.indexOf(key) > -1) return pluginDone(null, 0);
 
             plugin.run(collection, settings, function(err, results) {
+                if (!results.length) return console.log('ERROR: Nothing to report...');
                 for (var r in results) {
                     // If we have suppressed this result, then don't process it
                     // so that it doesn't affect the return code.
                     if (suppressionFilter([key, results[r].region || 'any', results[r].resource || 'any'].join(':'))) {
                         continue;
                     }
-                    
+
                     var complianceMsg = [];
                     if (settings.compliance && settings.compliance.length) {
                         settings.compliance.forEach(function(c){


### PR DESCRIPTION
Hi guys, 

When I running cloudsploit specifying some plugins the output is an `Invalid array length` error.

This pull request check if results of the plugin is null. 

Issue related: #322 

For example `$ ./index.js --config=./config.js --plugin flowLogsEnabled`

```
$ ./index.js --config=./config.js --plugin flowLogsEnabled

   _____ _                 _  _____       _       _ _
  / ____| |               | |/ ____|     | |     (_) |
 | |    | | ___  _   _  __| | (___  _ __ | | ___  _| |_
 | |    | |/ _ \| | | |/ _` |\___ \| '_ \| |/ _ \| | __|
 | |____| | (_) | |_| | (_| |____) | |_) | | (_) | | |_
  \_____|_|\___/ \__,_|\__,_|_____/| .__/|_|\___/|_|\__|
                                   | |
                                   |_|

  CloudSploit by Aqua Security, Ltd.
  Cloud security auditing for AWS, Azure, GCP, Oracle, and GitHub

INFO: Using CloudSploit config file: ./config.js
INFO: Skipping AWS pagination mode
INFO: Testing plugin: Flow Logs Enabled
INFO: Determining API calls to make...
INFO: Found 1 API calls to make for google plugins
INFO: Collecting metadata. This may take several minutes...
INFO: Metadata collection complete. Analyzing...
INFO: Analysis complete. Scan report to follow...
/data/node_modules/tty-table/src/format.js:172
            + Array(padBoth + 1 + padRemainder).join(" ")
              ^

RangeError: Invalid array length
    at /data/node_modules/tty-table/src/format.js:172:15
    at Array.map (<anonymous>)
    at Object.module.exports.wrapCellText (/data/node_modules/tty-table/src/format.js:156:35)
    at Object.module.exports.buildCell (/data/node_modules/tty-table/src/render.js:287:39)
    at /data/node_modules/tty-table/src/render.js:171:26
    at Array.map (<anonymous>)
    at Object.module.exports.buildRow (/data/node_modules/tty-table/src/render.js:170:13)
    at /data/node_modules/tty-table/src/render.js:47:24
    at Array.map (<anonymous>)
    at Object.module.exports.stringifyData (/data/node_modules/tty-table/src/render.js:46:45)

```

Console log after validated the `results`. 

```
root@f78a8222f2a9:/data# ./index.js --config=./config.js --plugin flowLogsEnabled

   _____ _                 _  _____       _       _ _
  / ____| |               | |/ ____|     | |     (_) |
 | |    | | ___  _   _  __| | (___  _ __ | | ___  _| |_
 | |    | |/ _ \| | | |/ _` |\___ \| '_ \| |/ _ \| | __|
 | |____| | (_) | |_| | (_| |____) | |_) | | (_) | | |_
  \_____|_|\___/ \__,_|\__,_|_____/| .__/|_|\___/|_|\__|
                                   | |
                                   |_|

  CloudSploit by Aqua Security, Ltd.
  Cloud security auditing for AWS, Azure, GCP, Oracle, and GitHub

INFO: Using CloudSploit config file: ./config.js
INFO: Skipping AWS pagination mode
INFO: Testing plugin: Flow Logs Enabled
INFO: Determining API calls to make...
INFO: Found 1 API calls to make for google plugins
INFO: Collecting metadata. This may take several minutes...
INFO: Metadata collection complete. Analyzing...
INFO: Analysis complete. Scan report to follow...
ERROR: Nothing to report...
```

It is still necessary to identify and correct each plugin that is not working individually.

I believe that it needs information that is collected in other api calls, because the plugins work correctly when not executed individually.