### PR TITLE
Bugfix/plugins/google/logging/: fix status of projectOwnershipLogging when log metrics not found

### DIFF
--- a/plugins/google/logging/projectOwnershipLogging.js
+++ b/plugins/google/logging/projectOwnershipLogging.js
@@ -44,12 +44,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/projectOwnershipLogging.spec.js
+++ b/plugins/google/logging/projectOwnershipLogging.spec.js
@@ -30,7 +30,7 @@ describe('projectOwnershipLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('projectOwnershipLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()


### PR DESCRIPTION
Hi guys,

Currently when I run the `projectOwnershipLogging` plugin it returns ok when I do not have log metrics or alert policies. 

I think the correct thing would be to return fail, according to the description of the plugin: [here](https://github.com/aquasecurity/cloudsploit/blob/master/plugins/google/logging/projectOwnershipLogging.js#L7).

```
$ ./index.js --config=./config.js --plugin projectOwnershipLogging

   _____ _                 _  _____       _       _ _
  / ____| |               | |/ ____|     | |     (_) |
 | |    | | ___  _   _  __| | (___  _ __ | | ___  _| |_
 | |    | |/ _ \| | | |/ _` |\___ \| '_ \| |/ _ \| | __|
 | |____| | (_) | |_| | (_| |____) | |_) | | (_) | | |_
  \_____|_|\___/ \__,_|\__,_|_____/| .__/|_|\___/|_|\__|
                                   | |
                                   |_|

  CloudSploit by Aqua Security, Ltd.
  Cloud security auditing for AWS, Azure, GCP, Oracle, and GitHub

INFO: Using CloudSploit config file: ./config.js
INFO: Skipping AWS pagination mode
INFO: Testing plugin: Project Ownership Logging
INFO: Determining API calls to make...
INFO: Found 2 API calls to make for google plugins
INFO: Collecting metadata. This may take several minutes...
INFO: Metadata collection complete. Analyzing...
INFO: Analysis complete. Scan report to follow...

  ┌────────┬────────────────┬────────────────────────────────────────────────────────┬──────┬────┬────────┬─────────────┐
  │ Catego │     Plugin     │                      Description                       │ Reso │ Re │ Status │   Message   │
  │   ry   │                │                                                        │ urce │ gi │        │             │
  │        │                │                                                        │      │ on │        │             │
  ├────────┼────────────────┼────────────────────────────────────────────────────────┼──────┼────┼────────┼─────────────┤
  │ Loggin │ Project        │ Ensures that logging and log alerts exist for project  │ N/A  │ gl │ OK     │ No log      │
  │ g      │ Ownership      │ ownership assignments and changes                      │      │ ob │        │ metrics     │
  │        │ Logging        │                                                        │      │ al │        │ found       │
  └────────┴────────────────┴────────────────────────────────────────────────────────┴──────┴────┴────────┴─────────────┘
INFO: Scan complete
```

This pull request changes the `Status` to `FAIL` when log metrics or alert policies not found in the project. 

```
$ ./index.js --config=./config.js --console=table --plugin projectOwnershipLogging

   _____ _                 _  _____       _       _ _
  / ____| |               | |/ ____|     | |     (_) |
 | |    | | ___  _   _  __| | (___  _ __ | | ___  _| |_
 | |    | |/ _ \| | | |/ _` |\___ \| '_ \| |/ _ \| | __|
 | |____| | (_) | |_| | (_| |____) | |_) | | (_) | | |_
  \_____|_|\___/ \__,_|\__,_|_____/| .__/|_|\___/|_|\__|
                                   | |
                                   |_|

  CloudSploit by Aqua Security, Ltd.
  Cloud security auditing for AWS, Azure, GCP, Oracle, and GitHub

INFO: Using CloudSploit config file: ./config.js
INFO: Skipping AWS pagination mode
INFO: Testing plugin: Project Ownership Logging
INFO: Determining API calls to make...
INFO: Found 2 API calls to make for google plugins
INFO: Collecting metadata. This may take several minutes...
INFO: Metadata collection complete. Analyzing...
INFO: Analysis complete. Scan report to follow...

  ┌────────┬────────────────┬────────────────────────────────────────────────────────┬──────┬────┬────────┬─────────────┐
  │ Catego │     Plugin     │                      Description                       │ Reso │ Re │ Status │   Message   │
  │   ry   │                │                                                        │ urce │ gi │        │             │
  │        │                │                                                        │      │ on │        │             │
  ├────────┼────────────────┼────────────────────────────────────────────────────────┼──────┼────┼────────┼─────────────┤
  │ Loggin │ Project        │ Ensures that logging and log alerts exist for project  │ N/A  │ gl │ FAIL   │ No log      │
  │ g      │ Ownership      │ ownership assignments and changes                      │      │ ob │        │ metrics     │
  │        │ Logging        │                                                        │      │ al │        │ found       │
  └────────┴────────────────┴────────────────────────────────────────────────────────┴──────┴────┴────────┴─────────────┘
INFO: Scan complete

```

