### PR TITLE
Chore: Bumped to node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:14-alpine
 
 # Define a build argment that can be supplied when building the container
 # You can then do the following:


### PR DESCRIPTION
Node 8 was EOL as off 31st December 2019. Node 14 is the current LTS branch and is supported until 30th April 2023