### PR TITLE
Bugfix/plugins/google/logging/: fix status when log metrics or alert policies not found

### DIFF
--- a/plugins/google/logging/auditConfigurationLogging.js
+++ b/plugins/google/logging/auditConfigurationLogging.js
@@ -43,12 +43,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/auditConfigurationLogging.spec.js
+++ b/plugins/google/logging/auditConfigurationLogging.spec.js
@@ -30,7 +30,7 @@ describe('auditConfigurationLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('auditConfigurationLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/auditLoggingEnabled.js
+++ b/plugins/google/logging/auditLoggingEnabled.js
@@ -27,7 +27,7 @@ module.exports = {
             }
 
             if (!iamPolicies.data.length) {
-                helpers.addResult(results, 0, 'No IAM policies found.', region);
+                helpers.addResult(results, 2, 'No IAM policies found.', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/auditLoggingEnabled.spec.js
+++ b/plugins/google/logging/auditLoggingEnabled.spec.js
@@ -20,7 +20,7 @@ describe('auditLoggingEnabled', function () {
         it('should give passing result if no iam policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No IAM policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/customRoleLogging.js
+++ b/plugins/google/logging/customRoleLogging.js
@@ -41,12 +41,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/customRoleLogging.spec.js
+++ b/plugins/google/logging/customRoleLogging.spec.js
@@ -30,7 +30,7 @@ describe('customRoleLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('customRoleLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/logSinksEnabled.js
+++ b/plugins/google/logging/logSinksEnabled.js
@@ -27,7 +27,7 @@ module.exports = {
             }
 
             if (!sinks.data.length) {
-                helpers.addResult(results, 0, 'No sinks found', region);
+                helpers.addResult(results, 2, 'No sinks found', region);
                 return rcb();
             }
             var noSinks = true;

--- a/plugins/google/logging/logSinksEnabled.spec.js
+++ b/plugins/google/logging/logSinksEnabled.spec.js
@@ -30,7 +30,7 @@ describe('logSinksEnabled', function () {
         it('should give passing result if no sinks are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No sinks found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/sqlConfigurationLogging.js
+++ b/plugins/google/logging/sqlConfigurationLogging.js
@@ -41,12 +41,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/sqlConfigurationLogging.spec.js
+++ b/plugins/google/logging/sqlConfigurationLogging.spec.js
@@ -30,7 +30,7 @@ describe('sqlConfigurationLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('sqlConfigurationLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/storagePermissionsLogging.js
+++ b/plugins/google/logging/storagePermissionsLogging.js
@@ -45,12 +45,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/storagePermissionsLogging.spec.js
+++ b/plugins/google/logging/storagePermissionsLogging.spec.js
@@ -30,7 +30,7 @@ describe('storagePermissionsLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('storagePermissionsLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/vpcFirewallRuleLogging.js
+++ b/plugins/google/logging/vpcFirewallRuleLogging.js
@@ -41,12 +41,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/vpcFirewallRuleLogging.spec.js
+++ b/plugins/google/logging/vpcFirewallRuleLogging.spec.js
@@ -30,7 +30,7 @@ describe('vpcFirewallRuleLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('vpcFirewallRuleLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/vpcNetworkLogging.js
+++ b/plugins/google/logging/vpcNetworkLogging.js
@@ -44,12 +44,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/vpcNetworkLogging.spec.js
+++ b/plugins/google/logging/vpcNetworkLogging.spec.js
@@ -30,7 +30,7 @@ describe('vpcNetworkLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('vpcNetworkLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()

--- a/plugins/google/logging/vpcNetworkRouteLogging.js
+++ b/plugins/google/logging/vpcNetworkRouteLogging.js
@@ -41,12 +41,12 @@ module.exports = {
             }
 
             if (!metrics.data.length > 0) {
-                helpers.addResult(results, 0, 'No log metrics found', region);
+                helpers.addResult(results, 2, 'No log metrics found', region);
                 return rcb();
             }
 
             if (!alertPolicies.data.length > 0) {
-                helpers.addResult(results, 0, 'No log alert policies found', region);
+                helpers.addResult(results, 2, 'No log alert policies found', region);
                 return rcb();
             }
 

--- a/plugins/google/logging/vpcNetworkRouteLogging.spec.js
+++ b/plugins/google/logging/vpcNetworkRouteLogging.spec.js
@@ -30,7 +30,7 @@ describe('vpcNetworkRouteLogging', function () {
         it('should give passing result if no metrics are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log metrics found');
                 expect(results[0].region).to.equal('global');
                 done()
@@ -48,7 +48,7 @@ describe('vpcNetworkRouteLogging', function () {
         it('should give passing result if no alert policies are found', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[0].status).to.equal(0);
+                expect(results[0].status).to.equal(2);
                 expect(results[0].message).to.include('No log alert policies found');
                 expect(results[0].region).to.equal('global');
                 done()


### PR DESCRIPTION
Hi guys,

Currently when I run the logging plugins it returns ok when I do not have log metrics or alert policies.

Same as https://github.com/aquasecurity/cloudsploit/pull/358

This pull request changes the Status to FAIL when log metrics or alert policies not found in the project.

If it is better I can open a PR for each plugin.

Regards, 