### PR TITLE
Fix: Google DNSSecSigningAlgorithm Plugin Returns No Results When DNSSEC is Disabled

### DIFF
--- a/plugins/google/dns/dnsSecSigningAlgorithm.js
+++ b/plugins/google/dns/dnsSecSigningAlgorithm.js
@@ -10,12 +10,12 @@ module.exports = {
     recommended_action: 'Ensure that all managed zones using DNSSEC are not using the RSASHA1 algorithm for key or zone signing.',
     apis: ['managedZones:list'],
 
-    run: function (cache, settings, callback) {
+    run: function(cache, settings, callback) {
         var results = [];
         var source = {};
         var regions = helpers.regions();
 
-        async.each(regions.managedZones, function (region, rcb) {
+        async.each(regions.managedZones, function(region, rcb){
             let managedZones = helpers.addSource(cache, source,
                 ['managedZones', 'list', region]);
 
@@ -65,7 +65,7 @@ module.exports = {
             });
 
             rcb();
-        }, function () {
+        }, function(){
             // Global checking goes here
             callback(null, results, source);
         });

--- a/plugins/google/dns/dnsSecSigningAlgorithm.spec.js
+++ b/plugins/google/dns/dnsSecSigningAlgorithm.spec.js
@@ -157,9 +157,9 @@ describe('dnsSecSigningAlgorithm', function () {
         it('should give passing result if the managed zone does not have DNSSEC configuration', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);
-                expect(results[1].status).to.equal(0);
-                expect(results[1].message).to.include('RSASHA1 algorithm is not being used for zone signing');
-                expect(results[1].region).to.equal('global');
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('RSASHA1 algorithm is not being used for zone signing');
+                expect(results[0].region).to.equal('global');
                 done()
             };
 

--- a/plugins/google/dns/dnsSecSigningAlgorithm.spec.js
+++ b/plugins/google/dns/dnsSecSigningAlgorithm.spec.js
@@ -154,6 +154,39 @@ describe('dnsSecSigningAlgorithm', function () {
             plugin.run(cache, {}, callback);
         });
 
+        it('should give passing result if the managed zone does not have DNSSEC configuration', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[1].status).to.equal(0);
+                expect(results[1].message).to.include('RSASHA1 algorithm is not being used for zone signing');
+                expect(results[1].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [
+                    {
+                        "name": "giotestdnszone1",
+                        "dnsName": "cloudsploit.com.",
+                        "description": "",
+                        "id": "4534388710135378441",
+                        "nameServers": [
+                            "ns-cloud-e1.googledomains.com.",
+                            "ns-cloud-e2.googledomains.com.",
+                            "ns-cloud-e3.googledomains.com.",
+                            "ns-cloud-e4.googledomains.com."
+                        ],
+                        "creationTime": "2019-10-03T21:11:18.894Z",
+                        "visibility": "public",
+                        "kind": "dns#managedZone"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
         it('should give failing result if the managed zone has key signing using RSASHA1', function (done) {
             const callback = (err, results) => {
                 expect(results.length).to.be.above(0);


### PR DESCRIPTION
When DNSSEC is not enabled the managedZone object has no dnssecConfig property.

Line 62 is currently never hit because it is inside the if statement.