### PR TITLE
Fix: Google CorporateEmailsOnly Errors When Domain In IAM Policy

### DIFF
--- a/plugins/google/iam/corporateEmailsOnly.js
+++ b/plugins/google/iam/corporateEmailsOnly.js
@@ -10,12 +10,12 @@ module.exports = {
     recommended_action: 'Ensure that no users are actively using their Gmail accounts to access GCP.',
     apis: ['projects:getIamPolicy'],
 
-    run: function(cache, settings, callback) {
+    run: function (cache, settings, callback) {
         var results = [];
         var source = {};
         var regions = helpers.regions();
 
-        async.each(regions.projects, function(region, rcb){
+        async.each(regions.projects, function (region, rcb) {
             let iamPolicies = helpers.addSource(cache, source,
                 ['projects', 'getIamPolicy', region]);
 
@@ -31,15 +31,21 @@ module.exports = {
                 return rcb();
             }
 
+            console.log(iamPolicies)
+
             var iamPolicy = iamPolicies.data[0];
             var gmailUsers = [];
+            console.log(iamPolicy)
             iamPolicy.bindings.forEach(roleBinding => {
+                console.log(roleBinding)
                 if (roleBinding.members && roleBinding.members.length) {
                     roleBinding.members.forEach(member => {
                         var emailArr = member.split('@');
-                        var provider = emailArr[1].split('.');
-                        if (provider[0] === 'gmail' && (gmailUsers.indexOf(member) === -1)) {
-                            gmailUsers.push(member);
+                        if (emailArr.length > 1) {
+                            var provider = emailArr[1].split('.');
+                            if (provider[0] === 'gmail' && (gmailUsers.indexOf(member) === -1)) {
+                                gmailUsers.push(member);
+                            }
                         }
                     })
                 }
@@ -55,7 +61,7 @@ module.exports = {
 
 
             rcb();
-        }, function(){
+        }, function () {
             // Global checking goes here
             callback(null, results, source);
         });

--- a/plugins/google/iam/corporateEmailsOnly.js
+++ b/plugins/google/iam/corporateEmailsOnly.js
@@ -31,13 +31,9 @@ module.exports = {
                 return rcb();
             }
 
-            console.log(iamPolicies)
-
             var iamPolicy = iamPolicies.data[0];
             var gmailUsers = [];
-            console.log(iamPolicy)
             iamPolicy.bindings.forEach(roleBinding => {
-                console.log(roleBinding)
                 if (roleBinding.members && roleBinding.members.length) {
                     roleBinding.members.forEach(member => {
                         var emailArr = member.split('@');

--- a/plugins/google/iam/corporateEmailsOnly.js
+++ b/plugins/google/iam/corporateEmailsOnly.js
@@ -10,12 +10,12 @@ module.exports = {
     recommended_action: 'Ensure that no users are actively using their Gmail accounts to access GCP.',
     apis: ['projects:getIamPolicy'],
 
-    run: function (cache, settings, callback) {
+    run: function(cache, settings, callback) {
         var results = [];
         var source = {};
         var regions = helpers.regions();
 
-        async.each(regions.projects, function (region, rcb) {
+        async.each(regions.projects, function(region, rcb){
             let iamPolicies = helpers.addSource(cache, source,
                 ['projects', 'getIamPolicy', region]);
 
@@ -57,7 +57,7 @@ module.exports = {
 
 
             rcb();
-        }, function () {
+        }, function(){
             // Global checking goes here
             callback(null, results, source);
         });

--- a/plugins/google/iam/corporateEmailsOnly.spec.js
+++ b/plugins/google/iam/corporateEmailsOnly.spec.js
@@ -119,6 +119,12 @@ describe('corporateEmailsOnly', function () {
                                 "members": [
                                     "serviceAccount:service-281330800462@gcp-sa-websecurityscanner.iam.gserviceaccount.com"
                                 ]
+                            },
+                            {
+                                "role": "roles/iap.httpsResourceAccessor",
+                                "members": [
+                                    "domain:example.com"
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
It's possible for a domain to be used instead of an email address in an IAM policy which breaks when the plugin splits the string using the `@` character.

This change will allow the plugin to continue without error if it encounters an IAM member without an `@` in the name.