### PR TITLE
Check Kubernetes Cluster scopes independently

### DIFF
--- a/plugins/google/kubernetes/clusterLeastPrivilege.js
+++ b/plugins/google/kubernetes/clusterLeastPrivilege.js
@@ -43,9 +43,8 @@ module.exports = {
                 'https://www.googleapis.com/auth/trace.append'
             ];
 
-            let otherScope = false;
-
             clusters.data.forEach(cluster => {
+                let otherScope = false;
                 if (cluster.nodeConfig &&
                     cluster.nodeConfig.serviceAccount &&
                     cluster.nodeConfig.serviceAccount == 'default') {


### PR DESCRIPTION
I may be missing something, but it seems like there's a bug how it's currently written: if any Cluster has a bad scope, all subsequent Clusters will also be marked as out-of-scope because this variable isn't reset on each run.