### PR TITLE
ensure pluginDone is called under all circumstances

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -190,7 +190,6 @@ var engine = function(cloudConfig, settings) {
                     }
 
                 }
-                setTimeout(function() { pluginDone(err, maximumStatus); }, 0);
             };
 
             if (plugin.gsl) {
@@ -201,6 +200,8 @@ var engine = function(cloudConfig, settings) {
             } else {
                 plugin.run(collection, settings, postRun);
             }
+
+            setTimeout(function() { pluginDone(err, maximumStatus); }, 0);
         }, function(err) {
             if (err) return console.log(err);
             // console.log(JSON.stringify(collection, null, 2));

--- a/plugins/aws/iam/accessKeysRotated.spec.js
+++ b/plugins/aws/iam/accessKeysRotated.spec.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 const accessKeysRotated = require('./accessKeysRotated');
 
 var warnDate = new Date();
-warnDate.setMonth(warnDate.getMonth() - 3);
+warnDate.setMonth(warnDate.getMonth() - 4);
 var passDate = new Date();
 passDate.setMonth(passDate.getMonth() - 2);
 var failDate = new Date();


### PR DESCRIPTION
Fixes #552, Fixes #557 

The implementation of [async.mapValuesLimit](https://caolan.github.io/async/v3/mapValuesLimit.js.html) in `engine.collector` fails to resolve all of the asynchronous functions. This prevents the callback function from executing, which means `outputHandler.close()` never gets called. That means output is never written to the console, nor saved to JSON.

If we move the call to `pluginDone` out of the `if` statement, it is called under all circumstances, ensuring we get proper output.