### PR TITLE
Bump node-forge 0.9.1 to 0.10.0, fix high severity vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM node:lts-alpine3.12
 ARG PACKAGENAME=cloudsploit
 
 COPY . /var/scan/cloudsploit/
+COPY package-lock.json /var/scan
 
 # Install cloudsploit/scan into the container using npm from NPM
 RUN cd /var/scan \

--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,7 +2924,7 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
       "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
       "requires": {
-        "node-forge": "^0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "googleapis": {
@@ -4309,9 +4309,9 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "nodemon": {
       "version": "1.19.4",


### PR DESCRIPTION
The package node-forge before 0.10.0 is vulnerable to Prototype Pollution with high severity.  To fix this vulnerability we need to upgrade node-forge to 0.10.0.

Reference: https://www.npmjs.com/advisories/1561