### PR TITLE
HOTFIX: Modified VPC interface endpoint check

### DIFF
--- a/plugins/aws/ec2/vpcEndpointExposed.js
+++ b/plugins/aws/ec2/vpcEndpointExposed.js
@@ -10,7 +10,7 @@ module.exports = {
     link: 'https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-access.html',
     apis: ['EC2:describeVpcEndpoints', 'STS:getCallerIdentity'],
 
-    run: function(cache, settings, callback) {
+    run: function (cache, settings, callback) {
         var results = [];
         var source = {};
         var regions = helpers.regions(settings);
@@ -19,7 +19,7 @@ module.exports = {
         var awsOrGov = helpers.defaultPartition(settings);
         var accountId = helpers.addSource(cache, source, ['sts', 'getCallerIdentity', acctRegion, 'data']);
 
-        async.each(regions.ec2, function(region, rcb){
+        async.each(regions.ec2, function (region, rcb) {
             var describeVpcEndpoints = helpers.addSource(cache, source,
                 ['ec2', 'describeVpcEndpoints', region]);
 
@@ -43,13 +43,15 @@ module.exports = {
                 var statements = helpers.normalizePolicyDocument(endpoint.PolicyDocument);
                 var publicEndpoint = false;
 
-                for (var s in statements) {
-                    var statement = statements[s];
-                    
-                    if (statement.Effect == 'Allow') {
-                        if (helpers.globalPrincipal(statement.Principal)) {
-                            publicEndpoint = true;
-                            break;
+                if (!endpoint.ServiceName.startsWith('com.amazonaws.vpce')) {
+                    for (var s in statements) {
+                        var statement = statements[s];
+
+                        if (statement.Effect == 'Allow') {
+                            if (helpers.globalPrincipal(statement.Principal)) {
+                                publicEndpoint = true;
+                                break;
+                            }
                         }
                     }
                 }
@@ -66,7 +68,7 @@ module.exports = {
             }
 
             rcb();
-        }, function(){
+        }, function () {
             callback(null, results, source);
         });
     }


### PR DESCRIPTION
### Description:

VPC endpoint services for interface endpoints only support the full-access endpoint policy, so this plugin will always generate a false positive. 

### Summary of Changes:

A VPC endpoint will always start with `com.amazonaws.${region}.${service}` with the exception of VPC endpoint services for interface endpoints that always start with `com.amazonaws.vpce.${region}`. This change checks for interface endpoints using the above pattern.