### PR TITLE
override project with config.js value for google

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,11 @@ if (config.credentials.aws.credential_file && (!settings.cloud || (settings.clou
 } else if (config.credentials.google.credential_file && (!settings.cloud || (settings.cloud == 'google'))) {
     settings.cloud = 'google';
     cloudConfig = loadHelperFile(config.credentials.google.credential_file);
-    cloudConfig.project = cloudConfig.project_id;
+    if (config.credentials.google.project) {
+        cloudConfig.project = config.credentials.google.project;
+    } else {
+        cloudConfig.project = cloudConfig.project_id;
+    }
 } else if (config.credentials.google.project && (!settings.cloud || (settings.cloud == 'google'))) {
     settings.cloud = 'google';
     checkRequiredKeys(config.credentials.google, ['client_email', 'private_key']);


### PR DESCRIPTION
Google Cloud provides the possibility to define a service account which has access to multiple projects.
It would be useful to be able to change the project without the need to generate a new config file with the same credentials just to change the "project_id" key.

With the changes from above you can use the credentials.google.credential_file in the normal way.
If you uncomment the credentials.google.project and set it to env GOOGLE_PROJECT_ID then you can change the project id in a rapid manner with just a single credential file.