### PR TITLE
Add Aquasec AWS account 057012691312 to whitelist

### DIFF
--- a/plugins/aws/iam/trustedCrossAccountRoles.js
+++ b/plugins/aws/iam/trustedCrossAccountRoles.js
@@ -13,7 +13,7 @@ module.exports = {
             name: 'Whitelisted AWS Account Principals',
             description: 'A comma-separated list of trusted cross account principals',
             regex: '^.*$',
-            default: ''
+            default: 'arn:aws:iam::057012691312:root'
         },
         whitelisted_aws_account_principals_regex: {
             name: 'Whitelisted AWS Account Principals Regex',


### PR DESCRIPTION
### Expected behaviour

Cloudsploit doesn't flag its own configuration as a vulnerability.

### Actual behaviour

Cloudsploit runs from AWS account [057012691312](https://wave-support.aquasec.com/support/solutions/articles/16000111545-connecting-an-aws-account), but the Cloudsploit AWS account isn't included in the cross-account trust whitelist by default, which causes Cloudsploit to flag its own IAM role as a concern:

![image](https://user-images.githubusercontent.com/42976427/120054505-2be86a80-bfe5-11eb-987b-9317fa703dd3.png)
