### PR TITLE
Update gcp.md

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -8,7 +8,7 @@
 ```   
 name: roles/AquaCSPMSecurityAudit
 title: Aqua CSPM Security Audit
-  - includedPermissions:
+includedPermissions:
   - cloudkms.cryptoKeys.list
   - cloudkms.keyRings.list
   - cloudsql.instances.list


### PR DESCRIPTION
when using the file as is got the following error (excact file location dropped for security reason):
ERROR: (gcloud.iam.roles.create) Failed to parse YAML from .... in "aqua-security-audit-role.yaml", line 3, column 24

This change in line 3 fixed the issue