### PR TITLE
Fix condition key name of Amazon SNS topic policies

### DIFF
--- a/plugins/aws/sns/topicPolicies.js
+++ b/plugins/aws/sns/topicPolicies.js
@@ -86,7 +86,7 @@ module.exports = {
                         var conditionExists = (statement.Condition ? true : false);
                         // Is it a string condition (StringEquals)? Is the SourceOwner open to everyone?
                         var conditionString = ((statement.Condition && statement.Condition.StringEquals &&
-                            (statement.Condition.StringEquals['aws:SourceOwner'] || !statement.Condition.StringEquals['aws:SourceOwner'] == '*')) ? true : false);
+                            (statement.Condition.StringEquals['aws:SourceOwner'] && !statement.Condition.StringEquals['aws:SourceOwner'] == '*')) ? true : false);
                         // Is it an arn condition (ArnEquals)? Is the SourceArn open to all arns?
                         var conditionArn = false;
                         if (statement.Condition && statement.Condition.ArnEquals &&

--- a/plugins/aws/sns/topicPolicies.js
+++ b/plugins/aws/sns/topicPolicies.js
@@ -86,7 +86,7 @@ module.exports = {
                         var conditionExists = (statement.Condition ? true : false);
                         // Is it a string condition (StringEquals)? Is the SourceOwner open to everyone?
                         var conditionString = ((statement.Condition && statement.Condition.StringEquals &&
-                            (statement.Condition.StringEquals['AWS:SourceOwner'] || !statement.Condition.StringEquals['AWS:SourceOwner'] == '*')) ? true : false);
+                            (statement.Condition.StringEquals['aws:SourceOwner'] || !statement.Condition.StringEquals['aws:SourceOwner'] == '*')) ? true : false);
                         // Is it an arn condition (ArnEquals)? Is the SourceArn open to all arns?
                         var conditionArn = false;
                         if (statement.Condition && statement.Condition.ArnEquals &&

--- a/plugins/aws/sns/topicPolicies.js
+++ b/plugins/aws/sns/topicPolicies.js
@@ -86,7 +86,8 @@ module.exports = {
                         var conditionExists = (statement.Condition ? true : false);
                         // Is it a string condition (StringEquals)? Is the SourceOwner open to everyone?
                         var conditionString = ((statement.Condition && statement.Condition.StringEquals &&
-                            (statement.Condition.StringEquals['aws:SourceOwner'] && !statement.Condition.StringEquals['aws:SourceOwner'] == '*')) ? true : false);
+                            (statement.Condition.StringEquals['aws:SourceOwner'] && !statement.Condition.StringEquals['aws:SourceOwner'] == '*') ||
+                            (statement.Condition.StringEquals['AWS:SourceOwner'] && !statement.Condition.StringEquals['AWS:SourceOwner'] == '*')) ? true : false);
                         // Is it an arn condition (ArnEquals)? Is the SourceArn open to all arns?
                         var conditionArn = false;
                         if (statement.Condition && statement.Condition.ArnEquals &&

--- a/plugins/aws/sns/topicPolicies.js
+++ b/plugins/aws/sns/topicPolicies.js
@@ -85,9 +85,9 @@ module.exports = {
                         // Does the condition exist?
                         var conditionExists = (statement.Condition ? true : false);
                         // Is it a string condition (StringEquals)? Is the SourceOwner open to everyone?
-                        var conditionString = ((statement.Condition && statement.Condition.StringEquals &&
+                        var conditionString = ((statement.Condition && statement.Condition.StringEquals && (
                             (statement.Condition.StringEquals['aws:SourceOwner'] && !statement.Condition.StringEquals['aws:SourceOwner'] == '*') ||
-                            (statement.Condition.StringEquals['AWS:SourceOwner'] && !statement.Condition.StringEquals['AWS:SourceOwner'] == '*')) ? true : false);
+                            (statement.Condition.StringEquals['AWS:SourceOwner'] && !statement.Condition.StringEquals['AWS:SourceOwner'] == '*'))) ? true : false);
                         // Is it an arn condition (ArnEquals)? Is the SourceArn open to all arns?
                         var conditionArn = false;
                         if (statement.Condition && statement.Condition.ArnEquals &&

--- a/plugins/aws/sns/topicPolicies.spec.js
+++ b/plugins/aws/sns/topicPolicies.spec.js
@@ -144,7 +144,7 @@ const createNullCache = () => {
 describe('topicPolicies', function () {
     describe('run', function () {
         it('should PASS if SNS topic policy does not allow global access', function (done) {
-            const cache = createCache([listTopics[0]], getTopicAttributes[1]);
+            const cache = createCache([listTopics[0]], getTopicAttributes[0]);
             topicPolicies.run(cache, {}, (err, results) => {
                 expect(results.length).to.equal(1);
                 expect(results[0].status).to.equal(0);

--- a/plugins/aws/sns/topicPolicies.spec.js
+++ b/plugins/aws/sns/topicPolicies.spec.js
@@ -26,20 +26,6 @@ const getTopicAttributes = [
     {
         "ResponseMetadata": "{\"RequestId\": '2a205b73-5c0d-55e2-8129-0ca612f4a41c' }",
         "Attributes": {
-          "Policy": '{"Version":"2008-10-17","Id":"__default_policy_ID","Statement":[{"Sid":"__default_statement_ID","Effect":"Allow","Principal":{"AWS":"*"},"Action":["SNS:GetTopicAttributes","SNS:SetTopicAttributes","SNS:AddPermission","SNS:RemovePermission","SNS:DeleteTopic","SNS:Subscribe","SNS:ListSubscriptionsByTopic","SNS:Publish","SNS:Receive"],"Resource":"arn:aws:sns:us-east-1:111122223333:test-138-cmk","Condition":{"StringEquals":{"AWS:SourceOwner":"111122223333"}}}]}',
-          "Owner": '111122223333',
-          "SubscriptionsPending": "0",
-          "KmsMasterKeyId": 'arn:aws:kms:us-east-1:111122223333:key/b8789907-b7f7-438d-847e-7d468bac86b2',
-          "TopicArn": 'arn:aws:sns:us-east-1:111122223333:test-138-cmk',
-          "EffectiveDeliveryPolicy": '{"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,"numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}',
-          "SubscriptionsConfirmed": "0",
-          "DisplayName": "",
-          "SubscriptionsDeleted": "0"
-        }
-    },
-    {
-        "ResponseMetadata": "{\"RequestId\": '2a205b73-5c0d-55e2-8129-0ca612f4a41c' }",
-        "Attributes": {
             "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Resource\":\"arn:aws:sns:us-east-1:111122223333:test-spec\",\"Condition\":{}}]}",
             "Owner": "111122223333",
             "SubscriptionsPending": "0",
@@ -153,7 +139,7 @@ describe('topicPolicies', function () {
         });
 
         it('should FAIL if SNS topic policy allows global access', function (done) {
-            const cache = createCache([listTopics[1]], getTopicAttributes[2]);
+            const cache = createCache([listTopics[1]], getTopicAttributes[1]);
             topicPolicies.run(cache, {}, (err, results) => {
                 expect(results.length).to.equal(1);
                 expect(results[0].status).to.equal(2);
@@ -189,7 +175,7 @@ describe('topicPolicies', function () {
         });
 
         it('should UNKNOWN if SNS topic does not have a policy attached', function (done) {
-            const cache = createTopicAttributesErrorCache([listTopics[2]], getTopicAttributes[3]);
+            const cache = createTopicAttributesErrorCache([listTopics[2]], getTopicAttributes[2]);
             topicPolicies.run(cache, {}, (err, results) => {
                 expect(results.length).to.equal(1);
                 expect(results[0].status).to.equal(3);


### PR DESCRIPTION
Fix condition key case from `AWS:SourceOwner` to `aws:SourceOwner`.

According to the document, there should be start with `aws:` instead of `AWS:`.

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html
> Global condition keys are condition keys with an aws: prefix. 

https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-use-cases.html
> The aws:SourceAccount and aws:SourceOwner condition keys are similar in that they both identify a resource owner.