### PR TITLE
Added AWS ES plugin to validate usage of TLS 1.2

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -195,6 +195,7 @@ module.exports = {
         'esLoggingEnabled'              : require(__dirname + '/plugins/aws/es/esLoggingEnabled.js'),
         'esUpgradeAvailable'            : require(__dirname + '/plugins/aws/es/esUpgradeAvailable.js'),
         'esHttpsOnly'                   : require(__dirname + '/plugins/aws/es/esHttpsOnly.js'),
+        'esTlsPolicy'                   : require(__dirname + '/plugins/aws/es/esTlsPolicy.js'),
 
         'glueCloudwatchLogsEncrypted'   : require(__dirname + '/plugins/aws/glue/glueCloudwatchLogsEncrypted.js'),
         'glueS3EncryptionEnabled'       : require(__dirname + '/plugins/aws/glue/glueS3EncryptionEnabled.js'),

--- a/plugins/aws/es/esTlsPolicy.js
+++ b/plugins/aws/es/esTlsPolicy.js
@@ -1,0 +1,68 @@
+var async = require('async');
+var helpers = require('../../../helpers/aws');
+
+var goodTlsPolicies = ['Policy-Min-TLS-1-2-2019-07'];
+
+module.exports = {
+    title: 'ElasticSearch TLS Policy',
+    category: 'ES',
+    description: 'Ensures ElasticSearch enables TLS 1.2 encryption',
+    more_info: 'Its recommended for ElasticSearch domains to enable TLS 1.2 or later',
+    link: 'https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/infrastructure-security.html',
+    recommended_action: 'Configure TLS 1.2 Policy for all ElasticSearch domains.',
+    apis: ['ES:listDomainNames', 'ES:describeElasticsearchDomain'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions(settings);
+
+        async.each(regions.es, function(region, rcb) {
+            var listDomainNames = helpers.addSource(cache, source,
+                ['es', 'listDomainNames', region]);
+
+            if (!listDomainNames) return rcb();
+
+            if (listDomainNames.err || !listDomainNames.data) {
+                helpers.addResult(
+                    results, 3,
+                    'Unable to query for ES domains: ' + helpers.addError(listDomainNames), region);
+                return rcb();
+            }
+
+            if (!listDomainNames.data.length){
+                helpers.addResult(results, 0, 'No ES domains found', region);
+                return rcb();
+            }
+
+            listDomainNames.data.forEach(function(domain){
+                var describeElasticsearchDomain = helpers.addSource(cache, source,
+                    ['es', 'describeElasticsearchDomain', region, domain.DomainName]);
+
+                if (!describeElasticsearchDomain ||
+                    describeElasticsearchDomain.err ||
+                    !describeElasticsearchDomain.data ||
+                    !describeElasticsearchDomain.data.DomainStatus) {
+                    helpers.addResult(
+                        results, 3,
+                        'Unable to query for ES domain config: ' + helpers.addError(describeElasticsearchDomain), region);
+                } else {
+                    var localDomain = describeElasticsearchDomain.data.DomainStatus;
+
+                    if (localDomain.DomainEndpointOptions &&
+                        goodTlsPolicies.indexOf(localDomain.DomainEndpointOptions.TLSSecurityPolicy) > -1) {
+                        helpers.addResult(results, 0,
+                            'ES domain is configured to use TLS 1.2 policy', region, localDomain.ARN);
+                    } else {
+                        helpers.addResult(results, 1,
+                            'ES domain is not configured to use TLS 1.2 policy', region, localDomain.ARN);
+                    }
+                }
+            });
+
+            rcb();
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/aws/es/esTlsPolicy.spec.js
+++ b/plugins/aws/es/esTlsPolicy.spec.js
@@ -1,0 +1,100 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var es = require('./esTlsPolicy');
+
+const createCache = (listData, descData) => {
+    return {
+        es: {
+            listDomainNames: {
+                'us-east-1': {
+                    err: null,
+                    data: listData
+                }
+            },
+            describeElasticsearchDomain: {
+                'us-east-1': {
+                    'mydomain': {
+                        err: null,
+                        data: descData
+                    }
+                }
+            }
+        }
+    }
+};
+
+describe('esTlsPolicy', function () {
+    describe('run', function () {
+        it('should give passing result if no ES domains present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.equal(1)
+                expect(results[0].status).to.equal(0)
+                expect(results[0].message).to.include('No ES domains found')
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                {}
+            );
+
+            es.run(cache, {}, callback);
+        })
+
+        it('should give error result if ES domain is not configured to enforce HTTPS', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.equal(1)
+                expect(results[0].status).to.equal(1)
+                expect(results[0].message).to.include('ES domain is not configured to use TLS 1.2 policy')
+                done()
+            };
+
+            const cache = createCache(
+                [
+                  {
+                    DomainName: 'mydomain'
+                  }
+                ],
+                {
+                  DomainStatus: {
+                    DomainName: 'mydomain',
+                    ARN: 'arn:1234',
+                    DomainEndpointOptions: {
+                        TLSSecurityPolicy: 'Policy-Min-TLS-1-0-2019-07'
+                    }
+                  }
+                }
+            );
+
+            es.run(cache, {}, callback);
+        })
+
+        it('should give passing result if ES domain is configured to enforce HTTPS', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.equal(1)
+                expect(results[0].status).to.equal(0)
+                expect(results[0].message).to.include('ES domain is configured to use TLS 1.2 policy')
+                done()
+            };
+
+            const cache = createCache(
+                [
+                  {
+                    DomainName: 'mydomain'
+                  }
+                ],
+                {
+                  DomainStatus: {
+                    DomainName: 'mydomain',
+                    ARN: 'arn:1234',
+                    DomainEndpointOptions: {
+                        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
+                    }
+                  }
+                }
+            );
+
+            es.run(cache, {}, callback);
+        })
+    })
+})


### PR DESCRIPTION
This commit closes #209

Hi all, would like to assist in this great project.
Used the esHttpsOnly plugin as a base to learn and build this plugin.

This according to AWS  ElasticSearch recommendation regarding usage of TLS 1.2 and can be found here:
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/infrastructure-security.html


Since TLS 1.0 is the default on ES, using it trows only a warning.

