### PR TITLE
Fixing the potential false-positive on plugin eksPrivateEndpoint.js reported on issue 823

### DIFF
--- a/plugins/aws/eks/eksPrivateEndpoint.js
+++ b/plugins/aws/eks/eksPrivateEndpoint.js
@@ -4,10 +4,10 @@ var helpers = require('../../../helpers/aws');
 module.exports = {
     title: 'EKS Private Endpoint',
     category: 'EKS',
-    description: 'Ensures the private endpoint setting is enabled for EKS clusters',
+    description: 'Ensures only private endpoint setting is single enabled for EKS clusters',
     more_info: 'EKS private endpoints can be used to route all traffic between the Kubernetes worker and control plane nodes over a private VPC endpoint rather than across the public internet.',
     link: 'https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html',
-    recommended_action: 'Enable the private endpoint setting for all EKS clusters.',
+    recommended_action: 'Disable the public endpoint setting for all EKS clusters.',
     apis: ['EKS:listClusters', 'EKS:describeCluster', 'STS:getCallerIdentity'],
 
     run: function(cache, settings, callback) {
@@ -54,10 +54,10 @@ module.exports = {
 
                 if (describeCluster.data.cluster &&
                     describeCluster.data.cluster.resourcesVpcConfig &&
-                    describeCluster.data.cluster.resourcesVpcConfig.endpointPrivateAccess) {
-                    helpers.addResult(results, 0, 'EKS cluster has private endpoint enabled', region, arn);
+                    describeCluster.data.cluster.resourcesVpcConfig.endpointPublicAccess) {
+                    helpers.addResult(results, 2, 'EKS cluster does not have only the private endpoint enabled', region, arn);
                 } else {
-                    helpers.addResult(results, 2, 'EKS cluster does not have private endpoint enabled', region, arn);
+                    helpers.addResult(results, 0, 'EKS cluster has only the private endpoint enabled', region, arn);
                 }
             }
 


### PR DESCRIPTION
The EKS endpoint setting can have endpointPublicAccess as true, and endpointPrivateAccess as true too. So, just checking if endpointPrivateAccess is true can result in a false positive.

The right way to check it is to find **endpointPublicAccess as true**. Or if **endpointPrivateAccess is enabled AND endpointPublicAccess is disabled**.