### PR TITLE
Fix a typo in the YAML for the role

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -8,7 +8,8 @@
 ```   
 name: roles/AquaCSPMSecurityAudit
 title: Aqua CSPM Security Audit
-  - includedPermissions:
+# Permissions that are needed
+includedPermissions:
   - cloudkms.cryptoKeys.list
   - cloudkms.keyRings.list
   - cloudsql.instances.list


### PR DESCRIPTION
The role had a typo in it with`includedPermissions:` being  shown as part of the list, when it should have been at the top level. 

Removed the leading `-` and indent to make the YAML correct