### PR TITLE
GCP setup doesn't work with copy/paste due to typo

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -8,7 +8,7 @@
 ```   
 name: roles/AquaCSPMSecurityAudit
 title: Aqua CSPM Security Audit
-  - includedPermissions:
+includedPermissions:
   - cloudasset.assets.listResource
   - cloudkms.cryptoKeys.list
   - cloudkms.keyRings.list


### PR DESCRIPTION
Currently the docs doesn't work straight away because of a typo, this fixes that. 