### PR TITLE
Fixing the yaml file for GCP

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -8,7 +8,7 @@
 ```   
 name: roles/AquaCSPMSecurityAudit
 title: Aqua CSPM Security Audit
-  - includedPermissions:
+includedPermissions:
   - cloudasset.assets.listResource
   - cloudkms.cryptoKeys.list
   - cloudkms.keyRings.list


### PR DESCRIPTION
gcloud iam roles create will complain if there's a dash in front of "includedPermissions:".