### PR TITLE
fix a few missed repo renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A commercial version of CloudSploit hosted at Aqua Wave. Try [Aqua Wave](https:/
 Ensure that NodeJS is installed. If not, install it from [here](https://nodejs.org/download/).
 
 ```
-$ git clone git@github.com:cloudsploit/scans.git
+$ git clone git@github.com:aquasecurity/cloudsploit.git
 $ npm install
 ```
 

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -22,7 +22,7 @@ CloudFront: {
 },
 ```
 
-The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `CloudFront distributions`, and then loop through each one and run a more detailed call, you would add the `CloudFront:listDistributions` call in the [`calls`](https://github.com/cloudsploit/scans/blob/master/collectors/aws/collector.js#L58-L64) section and then the more detailed call in [`postcalls`](https://github.com/cloudsploit/scans/blob/master/collectors/aws/collector.js#L467-L473), setting it to rely on the output of `listDistributions` call.
+The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `CloudFront distributions`, and then loop through each one and run a more detailed call, you would add the `CloudFront:listDistributions` call in the [`calls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/aws/collector.js#L58-L64) section and then the more detailed call in [`postcalls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/aws/collector.js#L467-L473), setting it to rely on the output of `listDistributions` call.
 
 An example:  
 
@@ -37,7 +37,7 @@ getGroup: {
 
 This section tells CloudSploit to wait until the `IAM:listGroups` call has been made, and then loop through the data that is returned. The `filterKey` tells CloudSploit the name of the key from the original response, while `filterValue` tells it which property to set in the `getGroup` call filter. For example: `iam.getGroup({GroupName:abc})` where `abc` is the `GroupName` from the returned list. CloudSploit will loop through each response, re-invoking `getGroup` for each element.
 
-You can find the [AWS Collector here.](https://github.com/cloudsploit/scans/blob/master/collectors/aws/collector.js)
+You can find the [AWS Collector here.](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/aws/collector.js)
 
 #### Azure Collection
 
@@ -52,7 +52,7 @@ virtualMachines: {
 },
 ```
 
-The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `Virtual Machine instances`, and then loop through each one and run a more detailed call, you would add the `virtualMachines:listAll` call in the [`calls`](https://github.com/cloudsploit/scans/blob/master/collectors/azure/collector.js#L50-L55) section and then the more detailed call in [`postcalls`](https://github.com/cloudsploit/scans/blob/master/collectors/azure/collector.js#L293-L302), setting it to rely on the output of `listDistributions` call.
+The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `Virtual Machine instances`, and then loop through each one and run a more detailed call, you would add the `virtualMachines:listAll` call in the [`calls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/azure/collector.js#L50-L55) section and then the more detailed call in [`postcalls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/azure/collector.js#L293-L302), setting it to rely on the output of `listDistributions` call.
 
 ```
 virtualMachineExtensions: {
@@ -67,7 +67,7 @@ virtualMachineExtensions: {
 },
 ```
 
-You can find the [Azure Collector here.](https://github.com/cloudsploit/scans/blob/master/collectors/azure/collector.js)
+You can find the [Azure Collector here.](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/azure/collector.js)
 
 #### GCP Collection
 
@@ -83,7 +83,7 @@ buckets: {
 },
 ```
 
-The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `Storage Buckets`, and then loop through each one and run a more detailed call, you would add the `buckets:list` call in the [`calls`](https://github.com/cloudsploit/scans/blob/master/collectors/google/collector.js#L103-L109) section and then the more detailed call in [`postcalls`](https://github.com/cloudsploit/scans/blob/master/collectors/google/collector.js#L213-L223), setting it to rely on the output of `getIamPolicy` call.
+The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `Storage Buckets`, and then loop through each one and run a more detailed call, you would add the `buckets:list` call in the [`calls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/google/collector.js#L103-L109) section and then the more detailed call in [`postcalls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/google/collector.js#L213-L223), setting it to rely on the output of `getIamPolicy` call.
 
 ```
 buckets: {
@@ -99,7 +99,7 @@ buckets: {
 },
 ```
 
-You can find the [GCP Collector here.](https://github.com/cloudsploit/scans/blob/master/collectors/google/collector.js)
+You can find the [GCP Collector here.](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/google/collector.js)
 
 #### Oracle Collection
 
@@ -115,7 +115,7 @@ vcn: {
 },
 ```
 
-The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `VCNs`, and then loop through each one and run a more detailed call, you would add the `vcn:list` call in the [`calls`](https://github.com/cloudsploit/scans/blob/master/collectors/oracle/collector.js#L41-L47) section and then the more detailed call in [`postcalls`](https://github.com/cloudsploit/scans/blob/master/collectors/oracle/collector.js#L243-L251), setting it to rely on the output of `get` call.
+The second section in `collect.js` is `postcalls`, which is an array of objects defining API calls that rely on other calls first returned. For example, if you need to query for all `VCNs`, and then loop through each one and run a more detailed call, you would add the `vcn:list` call in the [`calls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/oracle/collector.js#L41-L47) section and then the more detailed call in [`postcalls`](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/oracle/collector.js#L243-L251), setting it to rely on the output of `get` call.
 
 ```
 vcn: {
@@ -129,7 +129,7 @@ vcn: {
 },
 ```
 
-You can find the [Oracle Collector here.](https://github.com/cloudsploit/scans/blob/master/collectors/oracle/collector.js)
+You can find the [Oracle Collector here.](https://github.com/aquasecurity/cloudsploit/blob/master/collectors/oracle/collector.js)
 
 ## Scanning Phase
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cloudsploit/scans.git"
+    "url": "https://github.com/aquasecurity/cloudsploit.git"
   },
   "keywords": [
     "aws",
@@ -32,7 +32,7 @@
   "author": "Aqua Security",
   "license": "GPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/cloudsploit/scans/issues"
+    "url": "https://github.com/aquasecurity/cloudsploit/issues"
   },
   "homepage": "https://cloud.aquasec.com",
   "publishConfig": {

--- a/plugins/aws/cloudwatchlogs/monitoringMetrics.js
+++ b/plugins/aws/cloudwatchlogs/monitoringMetrics.js
@@ -65,7 +65,7 @@ module.exports = {
     category: 'CloudWatchLogs',
     domain: 'Compliance',
     description: 'Ensures metric filters are setup for CloudWatch logs to detect security risks from CloudTrail.',
-    more_info: 'Sending CloudTrail logs to CloudWatch is only useful if metrics are setup to detect risky activity from those logs. There are numerous metrics that should be used. For the exact filter patterns, please see this plugin on GitHub: https://github.com/cloudsploit/scans/blob/master/plugins/aws/cloudwatchlogs/monitoringMetrics.js',
+    more_info: 'Sending CloudTrail logs to CloudWatch is only useful if metrics are setup to detect risky activity from those logs. There are numerous metrics that should be used. For the exact filter patterns, please see this plugin on GitHub: https://github.com/aquasecurity/cloudsploit/blob/master/plugins/aws/cloudwatchlogs/monitoringMetrics.js',
     recommended_action: 'Enable metric filters to detect malicious activity in CloudTrail logs sent to CloudWatch.',
     link: 'http://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html',
     apis: ['CloudTrail:describeTrails', 'CloudWatchLogs:describeMetricFilters'],


### PR DESCRIPTION
Looks like this used to be called "cloudsploit/scan"; I just did a find'n'replace.