### PR TITLE
Fix YAML for GCP Role

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -8,7 +8,7 @@
 ```   
 name: roles/AquaCSPMSecurityAudit
 title: Aqua CSPM Security Audit
-  - includedPermissions:
+includedPermissions:
   - cloudasset.assets.listResource
   - cloudkms.cryptoKeys.list
   - cloudkms.keyRings.list


### PR DESCRIPTION
The YAML used to define the GCP role had a small syntax error. See issue #909.
