### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ ENV PATH "$PATH:/var/scan/node_modules/.bin"
 # command line arguments to the run command to control how this executes.
 # Thus, you can use the parameters that you would normally give to index.js
 # when running in a container.
-ENTRYPOINT ["cloudsploit-scan"]
+ENTRYPOINT ["cloudsploitscan"]
 CMD []


### PR DESCRIPTION
The name of the link from /var/scan/node_modules/.bin has changed to cloudsploitscan
At the moment, when trying to run the docker container, docker throws an error complaining about cloudsploit-scan not being in the PATH
I did some debugging (just installed bash in the image build, and exec'd in to look around) and saw that the name had changed - and now the docker container runs