### PR TITLE
Add node12 to deprecated runtimes

### DIFF
--- a/plugins/aws/lambda/lambdaOldRuntimes.js
+++ b/plugins/aws/lambda/lambdaOldRuntimes.js
@@ -23,6 +23,7 @@ module.exports = {
             { 'id':'nodejs6.10', 'name': 'Node.js 6.10', 'endOfLifeDate': '2019-08-12' },
             { 'id':'nodejs8.10', 'name': 'Node.js 8.10', 'endOfLifeDate': '2020-03-06' },
             { 'id':'nodejs10.x', 'name': 'Node.js 10.x', 'endOfLifeDate': '2022-02-14' },
+            { 'id':'nodejs12.x', 'name': 'Node.js 12.x', 'endOfLifeDate': '2022-12-14' },
             { 'id':'dotnetcore2.1', 'name': '.Net Core 2.1', 'endOfLifeDate': '2022-02-14' },
             { 'id':'dotnetcore2.0', 'name': '.Net Core 2.0', 'endOfLifeDate': '2018-10-01' },
             { 'id':'dotnetcore1.0', 'name': '.Net Core 1.0', 'endOfLifeDate': '2019-06-27' },


### PR DESCRIPTION
Per AWS:
We are ending support for Node.js 12 in AWS Lambda. This follows Node.js 12 End-Of-Life (EOL) reached on April 30, 2022 [1].

As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting November 14, 2022, Lambda will no longer apply security patches and other updates to the Node.js 12 runtime used by Lambda functions, and functions using Node.js 12 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Node.js 12 runtime. Starting December 14, 2022, you will no longer be able to update existing functions using the Node.js 12 runtime.