### PR TITLE
Feature/cloudsploit gcp new rules p2

### DIFF
--- a/collectors/aws/collector.js
+++ b/collectors/aws/collector.js
@@ -28,9 +28,9 @@ AWS.config.update({httpOptions: {agent: agent}});
 
 var rateError = {message: 'rate', statusCode: 429};
 
-var apiRetryAttempts = 2;
+var apiRetryAttempts = 10;
 var apiRetryBackoff = 500;
-var apiRetryCap = 1000;
+var apiRetryCap = 5000;
 
 // Loop through all of the top-level collectors for each service
 var collect = function(AWSConfig, settings, callback) {
@@ -183,7 +183,7 @@ var collect = function(AWSConfig, settings, callback) {
                                         let retry_temp = Math.min(apiRetryCap, (apiRetryBackoff * (retryExponential + timestamp) ** retryCount));
                                         let retry_seconds = Math.round(retry_temp/retryLeveler + Math.random(0, retry_temp) * 5000);
 
-                                        console.log(`Trying ${callKey} again in: ${retry_seconds/1000} seconds`);
+                                        console.log(`Trying ${callKey}[${retryCount}] again in: ${retry_seconds/1000} seconds`);
                                         retries.push({seconds: Math.round(retry_seconds/1000)});
                                         return retry_seconds;
                                     },
@@ -207,7 +207,7 @@ var collect = function(AWSConfig, settings, callback) {
                                         let retry_temp = Math.min(apiRetryCap, (apiRetryBackoff * (retryExponential + timestamp) ** retryCount));
                                         let retry_seconds = Math.round(retry_temp/retryLeveler + Math.random(0, retry_temp) * 5000);
 
-                                        console.log(`Trying ${callKey} again in: ${retry_seconds/1000} seconds`);
+                                        console.log(`Trying ${callKey}[${retryCount}] again in: ${retry_seconds/1000} seconds`);
                                         retries.push({seconds: Math.round(retry_seconds/1000)});
                                         return retry_seconds;
                                     },
@@ -337,7 +337,7 @@ var collect = function(AWSConfig, settings, callback) {
                                             let retry_temp = Math.min(apiRetryCap, (apiRetryBackoff * (retryExponential + timestamp) ** retryCount));
                                             let retry_seconds = Math.round(retry_temp/retryLeveler + Math.random(0, retry_temp) * 5000);
 
-                                            console.log(`Trying ${callKey} again in: ${retry_seconds/1000} seconds`);
+                                            console.log(`Trying ${callKey}[${retryCount}] again in: ${retry_seconds/1000} seconds`);
                                             retries.push({seconds: Math.round(retry_seconds/1000)});
                                             return retry_seconds;
                                         },

--- a/collectors/google/collector.js
+++ b/collectors/google/collector.js
@@ -95,6 +95,14 @@ var calls = {
                 paginationKey: 'pageSize'
             }
         },
+        bigtable: {
+            list: {
+                url: 'https://bigtableadmin.googleapis.com/v2/projects/{projectId}/instances',
+                location: null,
+                pagination: true,
+                paginationKey: 'pageToken'
+           }
+        },
         manyApi: true,
     },
     instanceTemplates: {
@@ -196,11 +204,21 @@ var calls = {
         }
     },
     clusters: {
-        list: {
-            url: 'https://container.googleapis.com/v1/projects/{projectId}/locations/-/clusters',
-            location: null,
-            pagination: false
-        }
+        kubernetes: {
+            list: {
+                url: 'https://container.googleapis.com/v1/projects/{projectId}/locations/-/clusters',
+                location: null,
+                pagination: false
+            }
+        },
+        dataproc: {
+            list: { //https://dataproc.googleapis.com/v1/projects/{projectId}/clusters:list
+                url: 'https://dataproc.googleapis.com/v1/projects/{projectId}/regions/{locationId}/clusters',
+                location: 'region',
+                pagination: true
+            }
+        },
+        manyApi: true,
     },
     managedZones: {
         list: {
@@ -369,17 +387,6 @@ var postcalls = {
             reliesOnSubService: ['sql'],
             reliesOnCall: ['list'],
             properties: ['name'],
-            pagination: true
-        }
-    },
-    datasets: {
-        get: {
-            url: 'https://bigquery.googleapis.com/bigquery/v2/projects/{projectId}/datasets/{datasetId}',
-            location: null,
-            reliesOnService: ['datasets'],
-            reliesOnCall: ['list'],
-            properties: ['datasetId'],
-            subObj: ['datasetReference'],
             pagination: true
         }
     },

--- a/collectors/google/collector.js
+++ b/collectors/google/collector.js
@@ -111,6 +111,13 @@ var calls = {
             pagination: true
         }
     },
+    instanceGroupManagers: {
+        list: {
+            url: 'https://compute.googleapis.com/compute/v1/projects/{projectId}/zones/{locationId}/instanceGroupManagers',
+            location: 'zone',
+            pagination: true
+        }
+    },
     functions: {
         list : {
             url: 'https://cloudfunctions.googleapis.com/v1/projects/{projectId}/locations/{locationId}/functions',
@@ -293,6 +300,12 @@ var calls = {
             location: null,
             pagination: true
         }
+    },
+    apiKeys: {
+        list: {
+            url: 'https://apikeys.googleapis.com/v2/projects/{projectId}/locations/global/keys',
+            location: null
+        }
     }
 };
 
@@ -398,7 +411,36 @@ var postcalls = {
             pagination: true,
             paginationKey: 'pageSize'
         }
+    },
+    apiKeys: {
+        get: {
+            url: 'https://apikeys.googleapis.com/v2/{name}',
+            reliesOnService: ['apiKeys'],
+            reliesOnCall: ['list'],
+            properties: ['name']
+        }
+    },
+    images: {
+        getIamPolicy: {
+            url: 'https://compute.googleapis.com/compute/v1/projects/{projectId}/global/images/{name}/getIamPolicy',
+            reliesOnService: ['images'],
+            reliesOnCall: ['list'],
+            properties: ['name'],
+            pagination: false
+        }
     }
+};
+
+var tertiarycalls = {
+    cryptoKeys: {
+        getIamPolicy: {
+            url: 'https://cloudkms.googleapis.com/v1/{name}:getIamPolicy',
+            location: 'region',
+            reliesOnService: ['cryptoKeys'],
+            reliesOnCall: ['list'],
+            properties: ['name'],
+        }
+    },
 };
 
 var collect = function(GoogleConfig, settings, callback) {
@@ -409,9 +451,6 @@ var collect = function(GoogleConfig, settings, callback) {
 
     var regions = helpers.regions();
 
-    if (settings.gather) {
-        return callback(null, calls, postcalls);
-    }
     helpers.authenticate(GoogleConfig)
         .then(client => {
             async.eachOfLimit(calls, 10, function(call, service, serviceCb) {
@@ -426,8 +465,28 @@ var collect = function(GoogleConfig, settings, callback) {
                         postcallCb();
                     });
                 }, function() {
-                    JSON.stringify(collection, null, 2);
-                    callback(null, collection);
+                    async.eachOfLimit(tertiarycalls, 10, function(tertiaryCallObj, service, tertiaryCallCb) {
+                        helpers.processCall(GoogleConfig, collection, settings, regions, tertiaryCallObj, service, client, function() {
+                            tertiaryCallCb();
+                        });
+                    }, function() {
+                        if (collection && (!collection.projects || !collection.projects.get)) {
+                            collection.projects = {
+                                ...collection.projects,
+                                get: {
+                                    global: {
+                                        data: [
+                                            {
+                                                kind: 'compute#project',
+                                                name: GoogleConfig.project
+                                            }
+                                        ]
+                                    }
+                                }
+                            };
+                        }
+                        callback(null, collection);
+                    });
                 });
             });
         });

--- a/engine.js
+++ b/engine.js
@@ -62,7 +62,7 @@ var engine = function(cloudConfig, settings) {
 
         // Skip plugins that don't match the ID flag
         var skip = false;
-        if (settings.plugin && settings.plugin !== pluginId) {
+        if ((settings.plugin && settings.plugin !== pluginId) || (settings.plugins && !settings.plugins.includes(pluginId))) {
             skip = true;
         } else {
             // Skip GitHub plugins that do not match the run type

--- a/exports.js
+++ b/exports.js
@@ -890,6 +890,16 @@ module.exports = {
         'dnsLoggingEnabled'             : require(__dirname + '/plugins/google/vpcnetwork/dnsLoggingEnabled.js'),
         'openCustomPorts'               : require(__dirname + '/plugins/google/vpcnetwork/openCustomPorts.js'),
         'firewallLoggingMetadata'       : require(__dirname + '/plugins/google/vpcnetwork/firewallLoggingMetadata.js'),
+        'openCassandraClient'           : require(__dirname + '/plugins/google/vpcnetwork/openCassandraClient.js'),
+        'openCassandraInternode'        : require(__dirname + '/plugins/google/vpcnetwork/openCassandraInternode.js'),
+        'openCassandraMonitoring'       : require(__dirname + '/plugins/google/vpcnetwork/openCassandraMonitoring.js'),
+        'openCassandraThrift'           : require(__dirname + '/plugins/google/vpcnetwork/openCassandraThrift.js'),
+        'openElasticsearch'             : require(__dirname + '/plugins/google/vpcnetwork/openElasticsearch.js'),
+        'openInternalWeb'               : require(__dirname + '/plugins/google/vpcnetwork/openInternalWeb.js'),
+        'openLDAPS'                     : require(__dirname + '/plugins/google/vpcnetwork/openLDAPS.js'),
+        'openLDAP'                      : require(__dirname + '/plugins/google/vpcnetwork/openLDAP.js'),
+        'openMemcached'                 : require(__dirname + '/plugins/google/vpcnetwork/openMemcached.js'),
+        'openSNMP'                      : require(__dirname + '/plugins/google/vpcnetwork/openSNMP.js'),
 
         'instanceMaxCount'              : require(__dirname + '/plugins/google/compute/instanceMaxCount.js'),
         'instancesMultiAz'              : require(__dirname + '/plugins/google/compute/instancesMultiAz.js'),
@@ -921,9 +931,12 @@ module.exports = {
         'applicationConsistentSnapshots': require(__dirname + '/plugins/google/compute/applicationConsistentSnapshots.js'),
         'deprecatedImages'              : require(__dirname + '/plugins/google/compute/deprecatedImages.js'),
         'enableUsageExport'             : require(__dirname + '/plugins/google/compute/enableUsageExport.js'),
+        'instanceGroupAutoHealing'      : require(__dirname + '/plugins/google/compute/instanceGroupAutoHealing.js'),
+        'publicDiskImages'              : require(__dirname + '/plugins/google/compute/publicDiskImages.js'),
 
         'keyRotation'                   : require(__dirname + '/plugins/google/cryptographickeys/keyRotation.js'),
         'keyProtectionLevel'            : require(__dirname + '/plugins/google/cryptographickeys/keyProtectionLevel.js'),
+        'kmsPublicAccesss'              : require(__dirname + '/plugins/google/cryptographickeys/kmsPublicAccess.js'),
 
         'dbRestorable'                  : require(__dirname + '/plugins/google/sql/dbRestorable.js'),
         'dbAutomatedBackups'            : require(__dirname + '/plugins/google/sql/dbAutomatedBackups.js'),
@@ -947,6 +960,8 @@ module.exports = {
         'storageAutoIncreaseEnabled'    : require(__dirname + '/plugins/google/sql/storageAutoIncreaseEnabled.js'),
         'serverCertificateRotation'     : require(__dirname + '/plugins/google/sql/serverCertificateRotation.js'),
         'sqlCMKEncryption'              : require(__dirname + '/plugins/google/sql/sqlCMKEncryption.js'),
+        'mysqlLatestVersion'            : require(__dirname + '/plugins/google/sql/mysqlLatestVersion.js'),
+        'postgresqlLatestVersion'       : require(__dirname + '/plugins/google/sql/postgresqlLatestVersion.js'),
 
         'bucketVersioning'              : require(__dirname + '/plugins/google/storage/bucketVersioning.js'),
         'bucketLogging'                 : require(__dirname + '/plugins/google/storage/bucketLogging.js'),
@@ -1026,6 +1041,9 @@ module.exports = {
 
         'httpTriggerRequireHttps'       : require(__dirname + '/plugins/google/cloudfunctions/httpTriggerRequireHttps.js'),
         'ingressAllTrafficDisabled'     : require(__dirname + '/plugins/google/cloudfunctions/ingressAllTrafficDisabled.js'),
+
+        'apiKeyApplicationRestriction'  : require(__dirname + '/plugins/google/api/apiKeyApplicationRestriction.js'),
+        'apiKeyRotation'                : require(__dirname + '/plugins/google/api/apiKeyRotation.js'),
 
         'computeAllowedExternalIPs'     : require(__dirname + '/plugins/google/cloudresourcemanager/computeAllowedExternalIPs.js'),
         'disableAutomaticIAMGrants'     : require(__dirname + '/plugins/google/cloudresourcemanager/disableAutomaticIAMGrants.js'),

--- a/exports.js
+++ b/exports.js
@@ -933,6 +933,10 @@ module.exports = {
         'enableUsageExport'             : require(__dirname + '/plugins/google/compute/enableUsageExport.js'),
         'instanceGroupAutoHealing'      : require(__dirname + '/plugins/google/compute/instanceGroupAutoHealing.js'),
         'publicDiskImages'              : require(__dirname + '/plugins/google/compute/publicDiskImages.js'),
+        'diskLabelsAdded'               : require(__dirname + '/plugins/google/compute/diskLabelsAdded.js'),
+        'imageLabelsAdded'              : require(__dirname + '/plugins/google/compute/imageLabelsAdded.js'),
+        'instanceLabelsAdded'           : require(__dirname + '/plugins/google/compute/instanceLabelsAdded.js'),
+        'snapshotLabelsAdded'           : require(__dirname + '/plugins/google/compute/snapshotLabelsAdded.js'),
 
         'keyRotation'                   : require(__dirname + '/plugins/google/cryptographickeys/keyRotation.js'),
         'keyProtectionLevel'            : require(__dirname + '/plugins/google/cryptographickeys/keyProtectionLevel.js'),
@@ -970,6 +974,7 @@ module.exports = {
         'bucketUniformAccess'           : require(__dirname + '/plugins/google/storage/bucketUniformAccess.js'),
         'bucketLifecycleConfigured'     : require(__dirname + '/plugins/google/storage/bucketLifecycleConfigured.js'),
         'bucketEncryption'              : require(__dirname + '/plugins/google/storage/bucketEncryption.js'),
+        'bucketLabelsAdded'             : require(__dirname + '/plugins/google/storage/bucketLabelsAdded.js'),
 
         'clbHttpsOnly'                  : require(__dirname + '/plugins/google/clb/clbHttpsOnly.js'),
         'clbNoInstances'                : require(__dirname + '/plugins/google/clb/clbNoInstances.js'),
@@ -984,7 +989,6 @@ module.exports = {
         'serviceAccountKeyRotation'     : require(__dirname + '/plugins/google/iam/serviceAccountKeyRotation.js'),
         'serviceAccountManagedKeys'     : require(__dirname + '/plugins/google/iam/serviceAccountManagedKeys.js'),
         'corporateEmailsOnly'           : require(__dirname + '/plugins/google/iam/corporateEmailsOnly.js'),
-
         'serviceAccountTokenCreator'    : require(__dirname + '/plugins/google/iam/serviceAccountTokenCreator.js'),
         'memberAdmin'                   : require(__dirname + '/plugins/google/iam/memberAdmin.js'),
       
@@ -1014,6 +1018,7 @@ module.exports = {
 
         'dnsSecEnabled'                 : require(__dirname + '/plugins/google/dns/dnsSecEnabled.js'),
         'dnsSecSigningAlgorithm'        : require(__dirname + '/plugins/google/dns/dnsSecSigningAlgorithm.js'),
+        'dnsZoneLabelsAdded'            : require(__dirname + '/plugins/google/dns/dnsZoneLabelsAdded.js'),
 
         'auditLoggingEnabled'           : require(__dirname + '/plugins/google/logging/auditLoggingEnabled.js'),
         'projectOwnershipLogging'       : require(__dirname + '/plugins/google/logging/projectOwnershipLogging.js'),
@@ -1028,12 +1033,18 @@ module.exports = {
 
         'datasetAllUsersPolicy'         : require(__dirname + '/plugins/google/bigquery/datasetAllUsersPolicy.js'),
         'tablesCMKEncrypted'            : require(__dirname + '/plugins/google/bigquery/tablesCMKEncrypted.js'),
-      
+        'datasetLabelsAdded'            : require(__dirname + '/plugins/google/bigquery/datasetLabelsAdded.js'),
+
         'topicEncryption'               : require(__dirname + '/plugins/google/pubsub/topicEncryption.js'),
         'deadLetteringEnabled'          : require(__dirname + '/plugins/google/pubsub/deadLetteringEnabled.js'),
+        'topicLabelsAdded'              : require(__dirname + '/plugins/google/pubsub/topicLabelsAdded.js'),
 
         'dataflowHangedJobs'            : require(__dirname + '/plugins/google/dataflow/dataflowHangedJobs.js'),
         'dataflowJobsEncryption'        : require(__dirname + '/plugins/google/dataflow/dataflowJobsEncryption.js'),
+
+        'dataprocClusterEncryption'     : require(__dirname + '/plugins/google/dataproc/dataprocClusterEncryption.js'),
+        'dataprocClusterLabelsAdded'    : require(__dirname + '/plugins/google/dataproc/dataprocClusterLabelsAdded.js'),
+        'hadoopSecureModeEnabled'       : require(__dirname + '/plugins/google/dataproc/hadoopSecureModeEnabled.js'),
 
         'deleteExpiredDeployments'      : require(__dirname + '/plugins/google/deploymentmanager/deleteExpiredDeployments.js'),
 
@@ -1041,9 +1052,12 @@ module.exports = {
 
         'httpTriggerRequireHttps'       : require(__dirname + '/plugins/google/cloudfunctions/httpTriggerRequireHttps.js'),
         'ingressAllTrafficDisabled'     : require(__dirname + '/plugins/google/cloudfunctions/ingressAllTrafficDisabled.js'),
+        'cloudFunctionLabelsAdded'      : require(__dirname + '/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js'),
 
         'apiKeyApplicationRestriction'  : require(__dirname + '/plugins/google/api/apiKeyApplicationRestriction.js'),
         'apiKeyRotation'                : require(__dirname + '/plugins/google/api/apiKeyRotation.js'),
+
+        'bigtableInstanceLabelsAdded'   : require(__dirname + '/plugins/google/bigtable/bigtableInstanceLabelsAdded.js'),
 
         'computeAllowedExternalIPs'     : require(__dirname + '/plugins/google/cloudresourcemanager/computeAllowedExternalIPs.js'),
         'disableAutomaticIAMGrants'     : require(__dirname + '/plugins/google/cloudresourcemanager/disableAutomaticIAMGrants.js'),

--- a/helpers/google/regions.js
+++ b/helpers/google/regions.js
@@ -94,6 +94,7 @@ module.exports = {
     healthChecks: ['global'],
     targetHttpProxies: ['global'],
     instanceGroups: ['global'],
+    instanceGroupManagers: regions,
     autoscalers: ['global'],
     subnetworks: regions,
     projects: ['global'],
@@ -114,4 +115,5 @@ module.exports = {
     organizations: ['global'],
     deployments: ['global'],
     urlMaps: ['global'],
+    apiKeys: ['global']
 };

--- a/helpers/google/regions.js
+++ b/helpers/google/regions.js
@@ -81,7 +81,8 @@ module.exports = {
     instances: {
         compute: regions,
         sql: ['global'],
-        spanner: ['global']
+        spanner: ['global'],
+        bigtable: ['global']
     },
     functions: [
         'us-east1', 'us-east4', 'us-west2', 'us-west3', 'us-west4', 'us-central1', 'northamerica-northeast1', 'southamerica-east1',
@@ -98,7 +99,10 @@ module.exports = {
     autoscalers: ['global'],
     subnetworks: regions,
     projects: ['global'],
-    clusters: ['global'],
+    clusters: {
+        kubernetes: ['global'],
+        dataproc: regions
+    },
     managedZones: ['global'],
     metrics: ['global'],
     alertPolicies: ['global'],

--- a/index.js
+++ b/index.js
@@ -268,5 +268,12 @@ if (settings.remediate && settings.remediate.length) {
     }
 }
 
+if (config.settings) {
+    // Load custom plugins parameters
+    Object.keys(config.settings).forEach(function(key) {
+        settings[key] = config.settings[key];
+    });
+}
+
 // Now execute the scans using the defined configuration information.
 engine(cloudConfig, settings);

--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ parser.add_argument('--compliance', {
 parser.add_argument('--plugin', {
     help: 'A specific plugin to run. If none provided, all plugins will be run. Obtain from the exports.js file. E.g. acmValidation'
 });
+parser.add_argument('--plugins', {
+    help: 'A specific plugins to run. If none provided, all plugins will be run. Obtain from the exports.js file. E.g. acmValidation',
+    nargs: '+'
+});
 parser.add_argument('--govcloud', {
     help: 'AWS only. Enables GovCloud mode.',
     action: 'store_true'

--- a/other_modules/oci/helpers.js
+++ b/other_modules/oci/helpers.js
@@ -68,6 +68,11 @@ function call(OracleConfig, options, callback) {
             });
         });
 
+        request.on('error', (e) => {
+            console.log('ERROR:', e);
+            callback({code: e.code});
+        });
+
         // Create signature
         signature.sign(request, {
             key: OracleConfig.privateKey,

--- a/plugins/aws/s3/s3Encryption.js
+++ b/plugins/aws/s3/s3Encryption.js
@@ -11,6 +11,8 @@ const encryptionLevelMap = {
 };
 
 function statementTargetsAction(statement, targetAction) {
+    if (!statement.Action) return false;
+
     return Array.isArray(statement.Action)
         ? statement.Action.find(action => minimatch(targetAction, action))
         : minimatch(targetAction, statement.Action);

--- a/plugins/azure/sqlserver/noPublicAccess.js
+++ b/plugins/azure/sqlserver/noPublicAccess.js
@@ -49,8 +49,9 @@ module.exports = {
 
                         firewallRules.data.forEach(firewallRule => {
                             const startIpAddr = firewallRule['startIpAddress'];
+                            const endIpAddr = firewallRule['endIpAddress'];
 
-                            if ((startIpAddr && startIpAddr.toString().indexOf('0.0.0.0') > -1)) {
+                            if (startIpAddr === '0.0.0.0' && endIpAddr === '255.255.255.255') {
                                 publicAccess = true;
                             }
                         });

--- a/plugins/google/api/apiKeyApplicationRestriction.js
+++ b/plugins/google/api/apiKeyApplicationRestriction.js
@@ -1,0 +1,70 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'API Key Application Restriction',
+    category: 'API',
+    domain: 'Identity and Access Management',
+    description: 'Ensure there are no unrestricted API keys available within your GCP project.',
+    more_info: 'To reduce the risk of attacks, Google Cloud API keys should be restricted only to trusted hosts, HTTP referrers, and Android/iOS mobile applications.',
+    link: 'https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions',
+    recommended_action: 'Ensure that Application restrictions are set for all Google Cloud API Keys.',
+    apis: ['apiKeys:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, projects.err);
+            return callback(null, results, source);
+        }
+
+        let apiKeys = helpers.addSource(cache, source,
+            ['apiKeys', 'list', 'global']);
+
+        if (!apiKeys) return callback(null, results, source);
+
+        if (apiKeys.err || !apiKeys.data) {
+            helpers.addResult(results, 3, 'Unable to query API Keys for project', 'global', null, null, apiKeys.err);
+            return callback(null, results, source);
+        }
+
+        if (!apiKeys.data.length) {
+            helpers.addResult(results, 0, 'No API Keys found', 'global');
+            return callback(null, results, source);
+        }
+
+        apiKeys.data.forEach(key => {
+            let isRestricted = false;
+
+            if (key.restrictions) {
+                if (key.restrictions.browserKeyRestrictions && key.restrictions.browserKeyRestrictions.allowedReferrers
+                    && key.restrictions.browserKeyRestrictions.allowedReferrers.length) {
+                    isRestricted = key.restrictions.browserKeyRestrictions.allowedReferrers.every(referrer =>
+                        referrer.match(/^(\*\.)?([\w-]+\.)+[\w-]+$/)
+                    );
+                }
+                if (key.restrictions.serverKeyRestrictions && key.restrictions.serverKeyRestrictions.allowedIps
+                    && key.restrictions.serverKeyRestrictions.allowedIps.length) {
+                    let allowedIps = key.restrictions.serverKeyRestrictions.allowedIps;
+                    if (!(allowedIps.includes('0.0.0.0') || allowedIps.includes('0.0.0.0/0') || allowedIps.includes('::0'))) {
+                        isRestricted = true;
+                    }
+                }
+            }
+            if (isRestricted) {
+                helpers.addResult(results, 0,
+                    'API Key usage is restricted to trusted hosts, HTTP referrers, or applications', 'global', key.name);
+            } else {
+                helpers.addResult(results, 2,
+                    'API Key usage is not restricted to trusted hosts, HTTP referrers, or applications', 'global', key.name);
+            }
+        });
+
+        return callback(null, results, source);
+    }
+};

--- a/plugins/google/api/apiKeyApplicationRestriction.spec.js
+++ b/plugins/google/api/apiKeyApplicationRestriction.spec.js
@@ -1,0 +1,112 @@
+var expect = require('chai').expect;
+var plugin = require('./apiKeyApplicationRestriction');
+
+
+const apiKeys = [
+        {
+          "name": "projects/my-project/locations/global/keys/my-key-1",
+          "displayName": "API Key 1",
+          "restrictions": {
+            "browserKeyRestrictions": {
+                "allowedReferrers" : [ "www.google.com"]
+            }
+          },
+        },
+        {
+          "name": "projects/my-project/locations/global/keys/my-key-2",
+          "displayName": "API key 2",
+        }
+];
+
+const createCache = (list, err) => {
+    return {
+        apiKeys: {
+            list: {
+                'global': {
+                    err: err,
+                    data: list
+                }
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' } ]
+                }
+            }
+        }
+    }
+};
+
+describe('apiKeyApplicationRestriction', function () {
+    describe('run', function () {
+
+        it('should give unknown result if unable to query api keys', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query API Keys for project');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no api keys found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No API Keys found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if google cloud api key is restricted', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('API Key usage is restricted');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [apiKeys[0]],
+                null
+                );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if google cloud api key is not restricted', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('API Key usage is not restricted');
+                expect(results[0].region).to.equal('global')
+                done();
+            };
+
+            const cache = createCache(
+                [apiKeys[1]],
+                null);
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});

--- a/plugins/google/api/apiKeyRotation.js
+++ b/plugins/google/api/apiKeyRotation.js
@@ -1,0 +1,75 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'API Key Rotation',
+    category: 'API',
+    domain: 'Identity and Access Management',
+    description: 'Ensure that your Google Cloud API Keys are periodically regenerated.',
+    more_info: 'Make sure that your Google API Keys are regenerated regularly to avoid data leaks and unauthorized access through outdated API Keys.',
+    link: 'https://cloud.google.com/docs/authentication/api-keys',
+    recommended_action: 'Ensure that all your Google Cloud API keys are regenerated (rotated) after a specific period.',
+    apis: ['apiKeys:list'],
+    settings: {
+        api_keys_rotation_warn_interval: {
+            name: 'API Keys Rotation Warn Interval',
+            description: 'Return a warning result when api keys exceed this number of days without being rotated',
+            regex: '^[1-9]{1}[0-9]{0,3}$',
+            default: '45'
+        },
+        api_keys_rotation_fail_interval: {
+            name: 'API Keys Rotation Fail Interval',
+            description: 'Return a failing result when api keys exceed this number of days without being rotated',
+            regex: '^[1-9]{1}[0-9]{0,3}$',
+            default: '90'
+        }
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        var apiKeyRotationFailInterval = parseInt(settings.api_keys_rotation_fail_interval || this.settings.api_keys_rotation_fail_interval.default);
+        var apiKeyRotationWarnInterval = parseInt(settings.api_keys_rotation_warn_interval || this.settings.api_keys_rotation_warn_interval.default);
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, projects.err);
+            return callback(null, results, source);
+        }
+
+        let apiKeys = helpers.addSource(cache, source,
+            ['apiKeys', 'list', 'global']);
+
+        if (!apiKeys) return callback(null, results, source);
+
+        if (apiKeys.err || !apiKeys.data) {
+            helpers.addResult(results, 3, 'Unable to query API Keys for project', 'global', null, null, apiKeys.err);
+            return callback(null, results, source);
+        }
+
+        if (!apiKeys.data.length) {
+            helpers.addResult(results, 0, 'No API Keys found', 'global');
+            return callback(null, results, source);
+        }
+
+        apiKeys.data.forEach(key => {
+            var diffInDays = helpers.daysBetween(key.createTime, new Date());
+
+            if (diffInDays > apiKeyRotationFailInterval) {
+                helpers.addResult(results, 2,
+                    `API Key was last rotated ${diffInDays} days ago which is greater than ${apiKeyRotationFailInterval}`, 'global', key.name);
+            } else if (diffInDays > apiKeyRotationWarnInterval) {
+                helpers.addResult(results, 1,
+                    `API Key was last rotated ${diffInDays} days ago which is greater than ${apiKeyRotationWarnInterval}`, 'global', key.name);
+            } else {
+                helpers.addResult(results, 0,
+                    `API Key was last rotated ${diffInDays} days ago`, 'global', key.name);
+            }
+        });
+
+        return callback(null, results, source);
+    }
+};

--- a/plugins/google/api/apiKeyRotation.spec.js
+++ b/plugins/google/api/apiKeyRotation.spec.js
@@ -1,0 +1,130 @@
+var expect = require('chai').expect;
+var plugin = require('./apiKeyRotation');
+
+const apiKeys = [
+        {
+          "name": "projects/my-project/locations/global/keys/my-key-1",
+          "displayName": "API Key 1",
+          "createTime": new Date(),
+        },
+        {
+          "name": "projects/my-project/locations/global/keys/my-key-2",
+          "displayName": "API key 2",
+          "createTime": '2021-04-07T17:23:05.126949Z',
+
+        },
+        {
+            "name": "projects/my-project/locations/global/keys/my-key-3",
+            "displayName": "API key 3",
+            "createTime": new Date().setMonth(new Date().getMonth() - 2)
+        }
+];
+
+const createCache = (list, err) => {
+    return {
+        apiKeys: {
+            list: {
+                'global': {
+                    err: err,
+                    data: list
+                }
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' } ]
+                }
+            }
+        }
+    }
+};
+
+describe('restrictedAPIKeys', function () {
+    describe('run', function () {
+
+        it('should give unknown result if unable to query api keys', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query API Keys for project');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no api keys found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No API Keys found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if google cloud api key is not outdated', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [apiKeys[0]],
+                null
+                );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give warning result if google cloud api key rotation date is older than warn interval', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(1);
+                expect(results[0].message).to.include('which is greater than');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [apiKeys[2]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if google cloud api key is outdated', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('which is greater than');
+                expect(results[0].region).to.equal('global')
+                done();
+            };
+
+            const cache = createCache(
+                [apiKeys[1]],
+                null);
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});

--- a/plugins/google/bigquery/datasetAllUsersPolicy.js
+++ b/plugins/google/bigquery/datasetAllUsersPolicy.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Granting permissions to allUsers or allAuthenticatedUsers allows anyone to access the dataset. Such access might not be desirable if sensitive data is being stored in the dataset.',
     link: 'https://cloud.google.com/bigquery/docs/dataset-access-controls',
     recommended_action: 'Ensure that each dataset is configured so that no member is set to allUsers or allAuthenticatedUsers.',
-    apis: ['datasets:list', 'datasets:get', 'projects:get'],
+    apis: ['datasets:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -29,7 +29,7 @@ module.exports = {
 
         async.each(regions.datasets, function(region, rcb){
             let datasetsGet = helpers.addSource(cache, source,
-                ['datasets', 'get', region]);
+                ['datasets', 'list', region]);
 
             if (!datasetsGet) return rcb();
 

--- a/plugins/google/bigquery/datasetAllUsersPolicy.spec.js
+++ b/plugins/google/bigquery/datasetAllUsersPolicy.spec.js
@@ -40,7 +40,7 @@ const datasetGet = [
 const createCache = (err, data) => {
     return {
         datasets: {
-            get: {
+            list: {
                 'global': {
                     err: err,
                     data: data

--- a/plugins/google/bigquery/datasetLabelsAdded.js
+++ b/plugins/google/bigquery/datasetLabelsAdded.js
@@ -1,0 +1,67 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataset Labels Added',
+    category: 'BigQuery',
+    domain: 'Databases',
+    description: 'Ensure that all BigQuery datasets have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/bigquery/docs/adding-labels',
+    recommended_action: 'Ensure labels are added to all BigQuery datasets.',
+    apis: ['datasets:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.datasets, function(region, rcb){
+            let datasets = helpers.addSource(cache, source,
+                ['datasets', 'list', region]);
+
+            if (!datasets) return rcb();
+
+            if (datasets.err || !datasets.data) {
+                helpers.addResult(results, 3, 'Unable to query BigQuery datasets', region, null, null, datasets.err);
+                return rcb();
+            }
+
+            if (!datasets.data.length) {
+                helpers.addResult(results, 0, 'No BigQuery datasets found', region);
+                return rcb();
+            }
+
+            datasets.data.forEach(dataset => {
+                if (!dataset.id) return;
+
+                let resource = helpers.createResourceName('datasets', dataset.id.split(':')[1] || dataset.id, project);
+
+                if (dataset.labels &&
+                    Object.keys(dataset.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(dataset.labels).length} labels found for BigQuery dataset`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'BigQuery dataset does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/bigquery/datasetLabelsAdded.spec.js
+++ b/plugins/google/bigquery/datasetLabelsAdded.spec.js
@@ -1,0 +1,111 @@
+var expect = require('chai').expect;
+var plugin = require('./datasetLabelsAdded');
+
+const datasets = [
+    {
+        kind: 'bigquery#dataset',
+        id: 'testproj:ds1',
+        datasetReference: { datasetId: 'ds1', projectId: 'testproj' },
+        labels: { dataset1: 'label' },
+        location: 'us-central1'
+    },
+    {
+        kind: 'bigquery#dataset',
+        id: 'testproj:ds2',
+        datasetReference: { datasetId: 'ds2', projectId: 'testproj' },
+        labels: {},
+        location: 'us-central1'
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        datasets: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('datasetLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a dataset error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query BigQuery datasets');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no datasets are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No BigQuery datasets found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the dataset', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for BigQuery dataset');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [datasets[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the dataset', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('BigQuery dataset does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [datasets[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/bigquery/tablesCMKEncrypted.js
+++ b/plugins/google/bigquery/tablesCMKEncrypted.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'By default Google encrypts all datasets using Google-managed encryption keys. To have more control over the encryption process of your BigQuery dataset tables you can use Customer-Managed Keys (CMKs).',
     link: 'https://cloud.google.com/bigquery/docs/customer-managed-encryption',
     recommended_action: 'Ensure that each BigQuery dataset table has desired encryption level.',
-    apis: ['datasets:list', 'datasets:get', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['datasets:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         bigquery_tables_encryption_protection_level: {
             name: 'BigQuery Dataset Encryption Protection Level',
@@ -55,7 +55,7 @@ module.exports = {
             function(cb) {
                 async.each(regions.datasets, function(region, rcb) {
                     let datasetsGet = helpers.addSource(cache, source,
-                        ['datasets', 'get', region]);
+                        ['datasets', 'list', region]);
 
                     if (!datasetsGet) return rcb();
 

--- a/plugins/google/bigquery/tablesCMKEncrypted.spec.js
+++ b/plugins/google/bigquery/tablesCMKEncrypted.spec.js
@@ -52,7 +52,7 @@ const datasetGet = [
 const createCache = (err, data, keysErr, keysList) => {
     return {
         datasets: {
-            get: {
+            list: {
                 'global': {
                     err: err,
                     data: data

--- a/plugins/google/bigtable/bigtableInstanceLabelsAdded.js
+++ b/plugins/google/bigtable/bigtableInstanceLabelsAdded.js
@@ -1,0 +1,62 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'BigTable Instance Labels Added',
+    category: 'BigTable',
+    domain: 'Databases',
+    description: 'Ensure that all BigTable instances have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/bigtable/docs/creating-managing-labels',
+    recommended_action: 'Ensure labels are added to all BigTable instances.',
+    apis: ['instances:bigtable:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        async.each(regions.instances.bigtable, function(region, rcb){
+            let instances =  helpers.addSource(
+                cache, source, ['instances', 'bigtable', 'list', region]);
+
+            if (!instances) return rcb();
+
+            if (instances.err || !instances.data) {
+                helpers.addResult(results, 3, 'Unable to query BigTable instances', region, null, null, instances.err);
+                return rcb();
+            }
+
+            if (!instances.data.length) {
+                helpers.addResult(results, 0, 'No BigTable instances found', region);
+                return rcb();
+            }
+
+            instances.data.forEach(instance => {
+
+                if (instance.labels &&
+                    Object.keys(instance.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(instance.labels).length} labels found for BigTable instance`, region, instance.name);
+                } else {
+                    helpers.addResult(results, 2,
+                        'BigTable instance does not have any labels', region, instance.name);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/bigtable/bigtableInstanceLabelsAdded.spec.js
+++ b/plugins/google/bigtable/bigtableInstanceLabelsAdded.spec.js
@@ -1,0 +1,115 @@
+var expect = require('chai').expect;
+var plugin = require('./bigtableInstanceLabelsAdded');
+
+const instances = [
+    {
+        name: 'projects/testproj/instances/test-1',
+        displayName: 'test-1',
+        state: 'READY',
+        type: 'PRODUCTION',
+        labels: { 'label': 'label' },
+        createTime: '2022-10-15T22:02:43.720541615Z'
+    },
+    {
+        name: 'projects/testproj/instances/test-2',
+        displayName: 'test-2',
+        state: 'READY',
+        type: 'PRODUCTION',
+        createTime: '2022-10-15T22:02:43.720541615Z'
+    },
+
+];
+
+const createCache = (err, data) => {
+    return {
+        intances: {
+            bigtable: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('bigtableInstanceLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if an instance error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query BigTable instances');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no bigtable instances are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No BigTable instances found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the instance', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for BigTable instance');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [instances[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the instance', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('BigTable instance does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [instances[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js
+++ b/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js
@@ -1,0 +1,53 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Cloud Function Labels Added',
+    category: 'Cloud Functions',
+    domain: 'Serverless',
+    description: 'Ensure that all Cloud Functions have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/functions/docs/configuring',
+    recommended_action: 'Ensure labels are added to all Cloud Functions.',
+    apis: ['functions:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+        
+        async.each(regions.functions, (region, rcb) => {
+            var functions = helpers.addSource(cache, source,
+                ['functions', 'list', region]);
+
+            if (!functions) return rcb();
+
+            if (functions.err || !functions.data) {
+                helpers.addResult(results, 3,
+                    'Unable to query for Google Cloud Functions: ' + helpers.addError(functions), region, null, null, functions.err);
+                return rcb();
+            }
+
+            if (!functions.data.length) {
+                helpers.addResult(results, 0, 'No Google Cloud functions found', region);
+                return rcb();
+            }
+
+            functions.data.forEach(func => {
+                if (!func.name) return;
+
+                if (func.labels &&
+                    Object.keys(func.labels).length) {
+                    helpers.addResult(results, 0, `${Object.keys(func.labels).length} labels found for Cloud Function`, region, func.name);
+                } else {
+                    helpers.addResult(results, 2, 'Cloud Function does not have any labels', region, func.name);
+                }
+
+            });
+
+            rcb();
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.spec.js
+++ b/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.spec.js
@@ -1,0 +1,115 @@
+var expect = require('chai').expect;
+var plugin = require('./cloudFunctionLabelsAdded');
+
+
+const functions = [
+    {
+        "name": "projects/my-test-project/locations/us-central1/functions/function-1",
+        "status": "ACTIVE",
+        "entryPoint": "helloWorld",
+        "timeout": "60s",
+        "availableMemoryMb": 256,
+        "updateTime": "2021-09-24T06:18:15.265Z",
+        "runtime": "nodejs14",
+        "ingressSettings": "ALLOW_ALL"
+      },
+      {
+        "name": "projects/my-test-project/locations/us-central1/functions/function-1",
+        "status": "ACTIVE",
+        "entryPoint": "helloWorld",
+        "timeout": "60s",
+        "availableMemoryMb": 256,
+        "updateTime": "2021-09-24T06:18:15.265Z",
+        "versionId": "1",
+        "runtime": "nodejs14",
+        "ingressSettings": "ALLOW_INTERNAL_AND_GCLB",
+        "labels": { 'deployment-tool': 'console-cloud' }
+    
+      }
+];
+
+const createCache = (list, err) => {
+    return {
+        functions: {
+            list: {
+                'us-central1': {
+                    err: err,
+                    data: list
+                }
+            }
+        }
+    }
+};
+
+describe('cloudFunctionLabelsAdded', function () {
+    describe('run', function () {
+        it('should give passing result if no cloud functions found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Google Cloud functions found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give unknown result if unable to query for Google Cloud functions', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query for Google Cloud Functions');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                {message: 'error'},
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if google cloud function has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Cloud Function');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [functions[1]],
+                null
+                );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if google cloud function does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(
+                [functions[0]],
+                null            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});
+

--- a/plugins/google/compute/autoscaleEnabled.js
+++ b/plugins/google/compute/autoscaleEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Enabling autoscale increases efficiency and improves cost management for resources.',
     link: 'https://cloud.google.com/compute/docs/autoscaler/',
     recommended_action: 'Ensure autoscaling is enabled for all instance groups.',
-    apis: ['instanceGroups:aggregatedList', 'autoscalers:aggregatedList','clusters:list', 'projects:get'],
+    apis: ['instanceGroups:aggregatedList', 'autoscalers:aggregatedList','clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -56,7 +56,7 @@ module.exports = {
             return rcb();
         }, function() {
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', ['global']]);
+                ['clusters', 'kubernetes', 'list', ['global']]);
 
             if (clusters.err || !clusters.data) {
                 helpers.addResult(results, 3, 'Unable to query clusters', 'global', null, null, clusters.err);

--- a/plugins/google/compute/autoscaleEnabled.spec.js
+++ b/plugins/google/compute/autoscaleEnabled.spec.js
@@ -21,10 +21,12 @@ const createCache = (instanceData, autoscalers, instanceGroupsError, autoScalers
             }
         },
         clusters: {
-            list: {
-                'global': {
-                    data: clusters,
-                    err: null
+            kubernetes: {
+                list: {
+                    'global': {
+                        data: clusters,
+                        err: null
+                    }
                 }
             }
         },

--- a/plugins/google/compute/diskAutomaticBackupEnabled.js
+++ b/plugins/google/compute/diskAutomaticBackupEnabled.js
@@ -64,6 +64,8 @@ module.exports = {
             disksInRegion.forEach(disk => {
                 if (!disk.id || !disk.creationTimestamp) return;
 
+                if (disk.name && disk.name.startsWith('gke-')) return;
+
                 let resource = helpers.createResourceName('disks', disk.name, project, disk.locationType, disk.location);    
 
                 if (disk.resourcePolicies && disk.resourcePolicies.length) {

--- a/plugins/google/compute/diskLabelsAdded.js
+++ b/plugins/google/compute/diskLabelsAdded.js
@@ -1,0 +1,86 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Disk Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all Compute Disks have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all Compute Disks.',
+    apis: ['disks:aggregatedList'],
+    
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let disks = helpers.addSource(cache, source,
+            ['disks', 'aggregatedList', ['global']]);
+
+        if (!disks) return callback(null, results, source);
+
+        if (disks.err || !disks.data) {
+            helpers.addResult(results, 3, 'Unable to query compute disks', 'global', null, null, disks.err);
+            return callback(null, results, source);
+        }
+
+        regions.all_regions.forEach(region => {
+            var noDisks = [];
+            var zones = regions.zones;
+            let disksInRegion = [];
+            let regionData = disks.data[`regions/${region}`];
+
+            if (regionData && regionData['disks'] && regionData['disks'].length) {
+                disksInRegion = disks.data[`regions/${region}`].disks.map(disk => { return {...disk, locationType: 'region', location: region};});
+            }
+        
+            zones[region].forEach(zone => {
+                let disksInZone = [];
+                let zoneData = disks.data[`zones/${zone}`];
+               
+                if (zoneData && zoneData['disks'] && zoneData['disks'].length) {
+                    disksInZone = disks.data[`zones/${zone}`].disks.map(disk => { return {...disk, locationType: 'zone', location: zone};});
+                }
+
+                if (!disksInZone.length) {
+                    noDisks.push(zone);
+                }
+
+                disksInRegion = disksInRegion.concat(disksInZone);
+            });
+
+            disksInRegion.forEach(disk => {
+                if (!disk.id || !disk.creationTimestamp) return;
+
+                let resource = helpers.createResourceName('disks', disk.name, project, disk.locationType, disk.location);
+
+                if (disk.labels &&
+                    Object.keys(disk.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(disk.labels).length} labels found for compute disk`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Compute disk does not have any labels', region, resource);
+                }
+
+            });
+
+            if (noDisks.length) {
+                helpers.addResult(results, 0, `No compute disks found in following zones: ${noDisks.join(', ')}`, region);
+            }
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/compute/diskLabelsAdded.spec.js
+++ b/plugins/google/compute/diskLabelsAdded.spec.js
@@ -1,0 +1,133 @@
+var expect = require('chai').expect;
+var plugin = require('./diskLabelsAdded');
+
+const createCache = (diskData, error) => {
+    return {
+        disks: {
+            aggregatedList: {
+                'global': {
+                    data: diskData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('diskLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown if unable to query compute disks', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query compute disks');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if No compute disks found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No compute disks found');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if disk does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                {
+                    "regions/us-east1": {
+                        "disks": [
+                            {
+                                "id": "1111111",
+                                "creationTimestamp": "2021-09-23T12:58:54.065-07:00",
+                                "name": "disk-1",
+                                "sizeGb": "10",
+                                "status": "READY",
+                                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/disks/disk-1",
+                                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/diskTypes/pd-balanced",
+                                "labelFingerprint": "42WmSpB8rSM=",
+                                "region": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1",
+                                "physicalBlockSizeBytes": "4096",
+                                "kind": "compute#disk",
+                                "resourcePolicies": [
+                                    'https://www.googleapis.com/compute/v1/projects/my-project/regions/us-east1/resourcePolicies/schedule-1'
+                                  ],
+                            }
+                        ]
+                    },
+                }     
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if disk has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for compute disk');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                {
+                    "regions/us-east1": {
+                        "disks": [
+                            {
+                                "id": "1111111",
+                                "creationTimestamp": "2021-09-23T12:58:54.065-07:00",
+                                "name": "disk-1",
+                                "sizeGb": "10",
+                                "status": "READY",
+                                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/disks/disk-1",
+                                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/diskTypes/pd-balanced",
+                                "labelFingerprint": "42WmSpB8rSM=",
+                                "labels": {"test": "test"},
+                                "region": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1",
+                                "physicalBlockSizeBytes": "4096",
+                                "kind": "compute#disk"
+                            }
+                        ]
+                    },
+                }     
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+}); 

--- a/plugins/google/compute/imageLabelsAdded.js
+++ b/plugins/google/compute/imageLabelsAdded.js
@@ -1,0 +1,57 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Image Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all VM disk images have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all disk images.',
+    apis: ['images:list'],
+    
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let images = helpers.addSource(cache, source,
+            ['images', 'list', 'global']);
+
+        if (!images || images.err || !images.data) {
+            helpers.addResult(results, 3, 'Unable to query Disk Images: ' + helpers.addError(images), 'global');
+            return callback(null, results, source);
+        }
+
+        if (!images.data.length) {
+            helpers.addResult(results, 0, 'No Disk Images found', 'global');
+            return callback(null, results, source);
+        }
+        
+        images.data.forEach(image => {
+
+            let resource = helpers.createResourceName('images', image.name, project, 'global');
+
+            if (image.labels &&
+                Object.keys(image.labels).length) {
+                helpers.addResult(results, 0,
+                    `${Object.keys(image.labels).length} labels found for disk image`, 'global', resource);
+            } else {
+                helpers.addResult(results, 2,
+                    'Disk image does not have any labels', 'global', resource);
+            }
+
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/compute/imageLabelsAdded.spec.js
+++ b/plugins/google/compute/imageLabelsAdded.spec.js
@@ -1,0 +1,117 @@
+var expect = require('chai').expect;
+var plugin = require('./imageLabelsAdded');
+
+const images = [
+    {
+        "id": "1231",
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-1",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-1",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-1",
+        "kind": "compute#image"
+    },
+    {
+        "id": 1232,
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-2",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-2",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-2",
+        "labels": {"label-1": "test"},
+        "kind": "compute#image"
+    }
+];
+const createCache = (imageData, error) => {
+    return {
+        images: {
+            list: {
+                'global': {
+                    data: imageData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('imageLabelsAdded', function () {
+    describe('run', function () {
+
+        it('should give unknown if unable to query disk images', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Disk Images');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no disk images found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Disk Images found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if disk image does not have any labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[0]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if labels are added for disk image', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for disk image');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[1]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});

--- a/plugins/google/compute/instanceGroupAutoHealing.js
+++ b/plugins/google/compute/instanceGroupAutoHealing.js
@@ -1,0 +1,73 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Instance Group Auto Healing Enabled',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that instance groups have auto-healing enabled for high availability.',
+    more_info: 'To improve the availability of your application, configure a health check to verify that the application is responding as expected.',
+    link: 'https://cloud.google.com/compute/docs/instance-groups/autohealing-instances-in-migs',
+    recommended_action: 'Ensure autohealing is enabled for all instance groups.',
+    apis: ['instanceGroupManagers:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.instanceGroupManagers, (region, rcb) => {
+            var zones = regions.zones;
+            var noInstanceGroups = [];
+            async.each(zones[region], function(zone, zcb) {
+                var instanceGroupManagers = helpers.addSource(cache, source,
+                    ['instanceGroupManagers', 'list', zone]);
+
+                if (!instanceGroupManagers) return zcb();
+
+                if (instanceGroupManagers.err || !instanceGroupManagers.data) {
+                    helpers.addResult(results, 3, 'Unable to query instance groups', region, null, null, instanceGroupManagers.err);
+                    return zcb();
+                }
+
+                if (!instanceGroupManagers.data.length) {
+                    noInstanceGroups.push(zone);
+                    return zcb();
+                }
+
+                instanceGroupManagers.data.forEach(instanceGroupManager => {
+                    if (!instanceGroupManager.id || !instanceGroupManager.creationTimestamp) return;
+
+                    let resource = helpers.createResourceName('instanceGroupManagers', instanceGroupManager.name, project, 'zone', zone);
+
+                    if (instanceGroupManager.autoHealingPolicies && instanceGroupManager.autoHealingPolicies.length) {
+                        helpers.addResult(results, 0,
+                            'Instance Group has auto healing enabled', region, resource);
+                    } else {
+                        helpers.addResult(results, 2,
+                            'Instance Group does not have auto healing enabled', region, resource);
+                    }
+                });
+                zcb();
+            }, function() {
+                if (noInstanceGroups.length) {
+                    helpers.addResult(results, 0, `No instance groups found in following zones: ${noInstanceGroups.join(', ')}`, region);
+                }
+                rcb();
+            });
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/compute/instanceGroupAutoHealing.spec.js
+++ b/plugins/google/compute/instanceGroupAutoHealing.spec.js
@@ -1,0 +1,120 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var plugin = require('./instanceGroupAutoHealing');
+
+const createCache = (instanceData, error) => {
+    return {
+        instanceGroupManagers: {
+                list: {
+                    'us-central1-a': {
+                        data: instanceData,
+                        err: error
+                    }
+                }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'tets-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('instanceGroupAutohealing', function () {
+    describe('run', function () {
+        const settings = { instance_desired_machine_types: 'e2-micro' };
+        it('should give unknown if an instance group error occurs', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query instance groups');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, settings, callback);
+        });
+
+        it('should pass no VM Instances', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No instance groups found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, settings, callback);
+        });
+
+        it('should FAIL if instance group does not have auto healing enabled', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Instance Group does not have auto healing enabled');
+                done()
+            };
+            const cache = createCache(
+                [
+                    {
+                        "id": '11111111',
+                        "creationTimestamp": '2022-01-05T12:19:12.147-08:00',
+                        "name": 'instance-group-1',
+                        "description": '',
+                        "zone": 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a',
+                        "instanceGroup": 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/instanceGroups/instance-group-1',
+                        "baseInstanceName": 'instance-group-1',
+                        "autoHealingPolicies": []
+                    }
+                ],
+                null
+            );
+
+            plugin.run(cache, settings, callback);
+        })
+
+        it('should PASS if instance group has auto healing enabled', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.equal('Instance Group has auto healing enabled');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        "id": '11111111',
+                        "creationTimestamp": '2022-01-05T12:19:12.147-08:00',
+                        "name": 'instance-group-1',
+                        "description": '',
+                        "zone": 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a',
+                        "instanceGroup": 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/instanceGroups/instance-group-1',
+                        "baseInstanceName": 'instance-group-1',
+                        "autoHealingPolicies": [
+                            {
+                                "healthCheck": 'https://www.googleapis.com/compute/v1/projects/my-project/global/healthChecks/hc-1',
+                                "initialDelaySec": 300
+                              }
+                        ]
+                    }
+                ]
+            );
+
+            plugin.run(cache, settings, callback);
+        })
+
+    })
+});

--- a/plugins/google/compute/instanceLabelsAdded.js
+++ b/plugins/google/compute/instanceLabelsAdded.js
@@ -1,0 +1,72 @@
+var async   = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Instance Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all Virtual Machine instances have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all VM instances.',
+    apis: ['instances:compute:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.instances.compute, (region, rcb) => {
+            var zones = regions.zones;
+            var noInstances = [];
+            async.each(zones[region], function(zone, zcb) {
+                var instances = helpers.addSource(cache, source,
+                    ['instances', 'compute', 'list', zone ]);
+
+                if (!instances) return zcb();
+
+                if (instances.err || !instances.data) {
+                    helpers.addResult(results, 3, 'Unable to query instances', region, null, null, instances.err);
+                    return zcb();
+                }
+
+                if (!instances.data.length) {
+                    noInstances.push(zone);
+                    return zcb();
+                }
+
+                instances.data.forEach(instance => {
+                    let resource = helpers.createResourceName('instances', instance.name, project, 'zone', zone);
+
+                    if (instance.labels &&
+                        Object.keys(instance.labels).length) {
+                        helpers.addResult(results, 0,
+                            `${Object.keys(instance.labels).length} labels found for VM instance.`, region, resource);
+                    } else {
+                        helpers.addResult(results, 2,
+                            'VM instance does not have any labels', region, resource);
+                    }
+                });
+                zcb();
+            }, function() {
+                if (noInstances.length) {
+                    helpers.addResult(results, 0, `No instances found in following zones: ${noInstances.join(', ')}`, region);
+                }
+                rcb();
+            });
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/compute/instanceLabelsAdded.spec.js
+++ b/plugins/google/compute/instanceLabelsAdded.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./instanceLabelsAdded');
+
+const createCache = (instanceData, error) => {
+    return {
+        instances:
+            compute: {
+                list: {
+                    'us-central1-a': {
+                        data: instanceData,
+                        err: error
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testproj'
+                }
+            }
+        }
+    }
+};
+
+describe('instanceLabelsAdded', function () {
+    describe('run', function () {
+
+        it('should give unknown if an instance error occurs', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query instances');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass no VM Instances', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No instances found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if instance does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        "id": "1074579276103575670",
+                        "creationTimestamp": "2019-09-25T14:05:30.014-07:00",
+                        "name": "instance-2",
+                        "description": "",
+                        "tags": {
+                            "fingerprint": "42WmSpB8rSM="
+                        },
+                        "canIpForward": false,
+                        "labelFingerprint": "42WmSpB8rSM=",
+                        "startRestricted": false,
+                        "deletionProtection": false,
+                        "kind": "compute#instance"
+                    }
+                ],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if instance has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for VM instance');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        "id": "1074579276103575670",
+                        "creationTimestamp": "2019-09-25T14:05:30.014-07:00",
+                        "name": "instance-2",
+                        "description": "",
+                        "tags": {
+                            "fingerprint": "42WmSpB8rSM="
+                        },
+                        "canIpForward": false,
+                        "labelFingerprint": "42WmSpB8rSM=",
+                        "startRestricted": false,
+                        "labels": {"test": "test"},
+                        "kind": "compute#instance"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+})

--- a/plugins/google/compute/publicDiskImages.js
+++ b/plugins/google/compute/publicDiskImages.js
@@ -1,0 +1,81 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Public Disk Images',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that your disk images are not being shared publicly.',
+    more_info: 'To avoid exposing sensitive information, make sure that your virtual machine disk images are not being publicly shared with all other GCP accounts.',
+    link: 'https://cloud.google.com/compute/docs/images',
+    recommended_action: 'Ensure that your VM disk images are not accessible by allUsers or allAuthenticatedUsers.',
+    apis: ['images:list', 'images:getIamPolicy'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let images = helpers.addSource(cache, source,
+            ['images', 'list', 'global']);
+
+        if (!images || images.err || !images.data) {
+            helpers.addResult(results, 3, 'Unable to query Disk Images: ' + helpers.addError(images), 'global');
+            return callback(null, results, source);
+        }
+
+        if (!images.data.length) {
+            helpers.addResult(results, 0, 'No Disk Images found', 'global');
+            return callback(null, results, source);
+        }
+
+        let getImagesIamPolicies = helpers.addSource(cache, source,
+            ['images', 'getIamPolicy', 'global']);
+
+        if (!getImagesIamPolicies || getImagesIamPolicies.err || !getImagesIamPolicies.data) {
+            helpers.addResult(results, 3, 'Unable to query IAM Policies for Disk Images: ' + helpers.addError(getImagesIamPolicies), 'global');
+            return callback(null, results, source);
+        }
+
+        if (!getImagesIamPolicies.data.length) {
+            helpers.addResult(results, 0, 'No IAM Policies found', 'global');
+            return callback(null, results, source);
+        }
+
+        getImagesIamPolicies = getImagesIamPolicies.data;
+
+        images.data.forEach(image => {
+
+            let imageIamPolicy = getImagesIamPolicies.find(iamPolicy => iamPolicy.parent && iamPolicy.parent.id === image.id);
+
+            let resource = helpers.createResourceName('images', image.name, project, 'global');
+
+            if (!imageIamPolicy || !imageIamPolicy.bindings || !imageIamPolicy.bindings.length) {
+                helpers.addResult(results, 0,
+                    'No IAM Policies found for disk image', 'global', resource);
+            } else {
+                var allowedAllUsers = false;
+                imageIamPolicy.bindings.forEach(roleBinding => {
+                    if (roleBinding.role && roleBinding.members && roleBinding.members.length && (roleBinding.members.includes('allUsers') || roleBinding.members.includes('allAuthenticatedUsers'))) {
+                        allowedAllUsers = true;
+                    }
+                });
+                if (!allowedAllUsers) {
+                    helpers.addResult(results, 0, 'Disk Image is not publicly accessible', 'global', resource);
+                } else {
+                    helpers.addResult(results, 2, 'Disk Image is publicly accessible', 'global', resource);
+                }
+            }
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/compute/publicDiskImages.spec.js
+++ b/plugins/google/compute/publicDiskImages.spec.js
@@ -1,0 +1,241 @@
+var expect = require('chai').expect;
+var plugin = require('./publicDiskImages');
+
+const imagePolicies = [
+    {
+        "version": 1,
+        "etag": "BwXZ3RM6WFs=",
+        "bindings": [
+            {
+                "role": "roles/compute.imageUser",
+                "members": [
+                    "allUsers",
+                ]
+            },
+        ],
+        "parent": {
+            "id": "1231",
+            "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+            "name": "image-1",
+            "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-1",
+            "sourceDiskId": "4476293856257965646",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-1",
+
+            "kind": "compute#image"
+        }
+    },
+    {
+        "version": 1,
+        "etag": "BwXZ3RM6WFs=",
+        "bindings": [
+            {
+                "role": "roles/compute.imageUser",
+                "members": [
+                    "myserviceaccount@gmail.com",
+                ]
+            },
+        ],
+        "parent":  {
+            "id": 1232,
+            "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+            "name": "image-2",
+            "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-2",
+            "sourceDiskId": "4476293856257965646",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-2",
+            "kind": "compute#image"
+        }
+    }
+]
+const images = [
+    {
+        "id": "1231",
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-1",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-1",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-1",
+        "kind": "compute#image"
+    },
+    {
+        "id": 1232,
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-2",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-2",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-2",
+        "kind": "compute#image"
+    },
+    {
+        "id": "1233",
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-3",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-3",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-3",
+        "kind": "compute#image"
+    }
+];
+const createCache = (imageData, error, policyData, policyErr) => {
+    return {
+        images: {
+            list: {
+                'global': {
+                    data: imageData,
+                    err: error
+                }
+            },
+            getIamPolicy: {
+                'global': {
+                    data: policyData,
+                    err: policyErr
+
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('publicDiskImages', function () {
+    describe('run', function () {
+
+        it('should give unknown if unable to query disk images', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Disk Images');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error'],
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no disk images found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Disk Images found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null,
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give unknown if unable to query IAM Policies for disk images', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query IAM Policies for Disk Images');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                images,
+                null,
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no IAM Policies found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No IAM Policies found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                images,
+                null,
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if disk image is publicly accessible', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Disk Image is publicly accessible');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[0]],
+                null,
+                [imagePolicies[0]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no IAM policies are found for disk image', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No IAM Policies found for disk image');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[2]],
+                null,
+                [imagePolicies],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if disk image is not publicly accessible', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Disk Image is not publicly accessible');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[1]],
+                null,
+                [imagePolicies[1]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+    })
+});

--- a/plugins/google/compute/snapshotLabelsAdded.js
+++ b/plugins/google/compute/snapshotLabelsAdded.js
@@ -1,0 +1,70 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Snapshot Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that Compute disk snapshots have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all Compute disk snapshots.',
+    apis: ['snapshots:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+       
+        var project = projects.data[0].name;
+
+        let snapshots = helpers.addSource(cache, source,
+            ['snapshots', 'list', 'global']);
+
+        if (!snapshots) return callback(null, results, source);
+
+        if (snapshots.err || !snapshots.data) {
+            helpers.addResult(results, 3, 'Unable to query for disk snapshots: ' + helpers.addError(snapshots), 'global');
+            return callback(null, results, source);
+        }
+        if (!snapshots.data.length) {
+            helpers.addResult(results, 0, 'No disk snapshots found', 'global');
+            return callback(null, results, source);
+        }
+
+        var snapshotsFound = false;
+
+        snapshots.data.forEach(snapshot => {
+            if (snapshot.creationTimestamp) {
+
+                snapshotsFound = true;
+                let resource = helpers.createResourceName('snapshot', snapshot.name, project, 'global');
+
+                if (snapshot.labels &&
+                    Object.keys(snapshot.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(snapshot.labels).length} labels found for compute disk snapshot`, 'global', resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Compute disk snapshot does not have any labels', 'global', resource);
+                }
+
+            }
+        });
+
+        if (!snapshotsFound) {
+            helpers.addResult(results, 0, 'No snapshots found in the project', 'global', project);
+        }
+
+        callback(null, results, source);
+
+    }
+};

--- a/plugins/google/compute/snapshotLabelsAdded.spec.js
+++ b/plugins/google/compute/snapshotLabelsAdded.spec.js
@@ -1,0 +1,129 @@
+var expect = require('chai').expect;
+var plugin = require('./snapshotLabelsAdded');
+
+const createCache = (snapshotData, error) => {
+    return {
+        snapshots: {
+            list: {
+                'global': {
+                    data: snapshotData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('snapshotLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown if unable to query compute disk snapshots', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query for disk snapshots');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if No compute disk snapshots found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No disk snapshots found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if snapshot does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        id: '11111',
+                        creationTimestamp: '2020-09-08T01:48:16.346-07:00',
+                        name: 'snapshot-1',
+                        status: 'READY',
+                        sourceDisk: 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/disks/disk-1',
+                        sourceDiskId: '7633933784896409327',
+                        diskSizeGb: '10',
+                        storageBytes: '0',
+                        storageBytesStatus: 'UP_TO_DATE',
+                        selfLink: 'https://www.googleapis.com/compute/v1/projects/my-project-1/global/snapshots/snapshot-1',
+                        labelFingerprint: '42WmSpB8rSM=',
+                        storageLocations: ['us-central1'],
+                        downloadBytes: '1390',
+                        kind: 'compute#snapshot'
+                    }
+                ],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if snapshot has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for compute disk snapshot');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        id: '11111',
+                        creationTimestamp: new Date(),
+                        name: 'snapshot-1',
+                        status: 'READY',
+                        sourceDisk: 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/disks/disk-1',
+                        sourceDiskId: '7633933784896409327',
+                        diskSizeGb: '10',
+                        storageBytes: '0',
+                        labels: {test: "test"},
+                        storageBytesStatus: 'UP_TO_DATE',
+                        selfLink: 'https://www.googleapis.com/compute/v1/projects/my-project-1/global/snapshots/snapshot-1',
+                        labelFingerprint: '42WmSpB8rSM=',
+                        storageLocations: ['us-central1'],
+                        downloadBytes: '1390',
+                        kind: 'compute#snapshot'
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+});

--- a/plugins/google/cryptographickeys/kmsPublicAccess.js
+++ b/plugins/google/cryptographickeys/kmsPublicAccess.js
@@ -1,0 +1,94 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'KMS Public Access',
+    category: 'Cryptographic Keys',
+    domain: 'Application Integration',
+    description: 'Ensures cryptographic keys are not publicly accessible.',
+    more_info: 'To prevent exposing sensitive data and information leaks, make sure that your cryptokeys do not allow access from anonymous and public users.',
+    link: 'https://cloud.google.com/kms/docs/reference/permissions-and-roles',
+    recommended_action: 'Ensure that your cryptographic keys are not accessible by allUsers or allAuthenticatedUsers.',
+    apis: ['keyRings:list', 'cryptoKeys:list', 'cryptoKeys:getIamPolicy'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.keyRings, function(region, rcb) {
+            let keyRings = helpers.addSource(
+                cache, source, ['keyRings', 'list', region]);
+
+            if (!keyRings) return rcb();
+
+            if (keyRings.err || !keyRings.data) {
+                helpers.addResult(results, 3, 'Unable to query key rings', region, null, null, keyRings.err);
+                return rcb();
+            }
+
+            if (!keyRings.data.length) {
+                helpers.addResult(results, 0, 'No key rings found', region);
+                return rcb();
+            }
+
+            let cryptoKeys = helpers.addSource(
+                cache, source, ['cryptoKeys', 'list', region]);
+
+            if (!cryptoKeys) return rcb();
+
+            if (cryptoKeys.err || !cryptoKeys.data) {
+                helpers.addResult(results, 3, 'Unable to query cryptographic keys', region, null, null, cryptoKeys.err);
+                return rcb();
+            }
+
+            if (!cryptoKeys.data.length) {
+                helpers.addResult(results, 0, 'No cryptographic keys found', region);
+                return rcb();
+            }
+
+            let cryptoKeysIamPolicies = helpers.addSource(
+                cache, source, ['cryptoKeys', 'getIamPolicy', region]);
+
+            if (!cryptoKeysIamPolicies || cryptoKeysIamPolicies.err || !cryptoKeysIamPolicies.data) {
+                helpers.addResult(results, 3, 'Unable to query IAM Policies for Cryptographic Keys: ' + helpers.addError(cryptoKeysIamPolicies), region);
+                return rcb();
+            }
+
+            if (!cryptoKeysIamPolicies.data.length) {
+                helpers.addResult(results, 0, 'No IAM Policies found', region);
+                return rcb();
+            }
+
+            cryptoKeysIamPolicies = cryptoKeysIamPolicies.data;
+
+            cryptoKeys.data.forEach(cryptoKey => {
+                if (!cryptoKey.name) return;
+
+                let keyIamPolicy = cryptoKeysIamPolicies.find(iamPolicy => iamPolicy.parent && iamPolicy.parent.name === cryptoKey.name);
+
+                if (!keyIamPolicy || !keyIamPolicy.bindings || !keyIamPolicy.bindings.length) {
+                    helpers.addResult(results, 0,
+                        'No IAM Policies found for cryptographic key', region, cryptoKey.name);
+                } else {
+                    var allowedAllUsers = false;
+                    keyIamPolicy.bindings.forEach(roleBinding => {
+                        if (roleBinding.role && roleBinding.members && roleBinding.members.length && (roleBinding.members.includes('allUsers') || roleBinding.members.includes('allAuthenticatedUsers'))) {
+                            allowedAllUsers = true;
+                        }
+                    });
+                    if (!allowedAllUsers) {
+                        helpers.addResult(results, 0, 'Cryptographic Key is not publicly accessible', region, cryptoKey.name);
+                    } else {
+                        helpers.addResult(results, 2, 'Cryptographic Key is publicly accessible', region, cryptoKey.name);
+                    }
+                }
+            });
+
+            rcb();
+        }, function() {
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/cryptographickeys/kmsPublicAccess.spec.js
+++ b/plugins/google/cryptographickeys/kmsPublicAccess.spec.js
@@ -1,0 +1,231 @@
+var expect = require('chai').expect;
+var plugin = require('./kmsPublicAccess');
+
+const cryptoKeys = [
+    {
+        "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-cmek",
+        "rotationPeriod": '7776000s',
+        "purpose": "ENCRYPT_DECRYPT",
+        "createTime": "2021-06-15T13:22:44.808595111Z"
+    },
+    {
+        "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-cmek-1",
+        "primary": {
+            "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-cmek-1/cryptoKeyVersions/1",
+            "createTime": "2021-06-15T13:27:10.444152476Z",
+            "protectionLevel": "SOFTWARE",
+            "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+            "generateTime": "2021-06-15T13:27:10.444152476Z"
+        },
+    },
+    {
+        "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-csek-1",
+        "purpose": "ENCRYPT_DECRYPT",
+        "createTime": "2021-06-15T14:05:00.127824829Z"
+    }
+];
+
+const keyPolicies = [
+    {
+        "version": 1,
+        "etag": "BwXZ3RM6WFs=",
+        "bindings": [
+            {
+                "role": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+                "members": [
+                    "allUsers",
+                ]
+            },
+        ],
+        "parent": {
+            "id": "1231",
+            "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+            "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-cmek"
+        }
+    },
+    {
+        "version": 1,
+        "etag": "BwXZ3RM6WFs=",
+        "bindings": [
+            {
+                "role": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+                "members": [
+                    "myserviceaccount@gmail.com",
+                ]
+            },
+        ],
+        "parent":  {
+            "id": 1232,
+            "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+            "name": "projects/test-project/locations/us-central1/keyRings/test-kr-1/cryptoKeys/test-cmek-1",
+        }
+    }
+]
+
+const createCache = (data, err, policyData, policyErr) => {
+    return {
+        keyRings: {
+            list: {
+                'us-central1': {
+                    data: [
+                        {
+                            'name': 'projects/test-project/locations/us-central1/keyRings/test-kr-1',
+                            'createTime': '2021-06-14T13:58:29.562215224Z'
+                        }
+                    ]
+                },
+            }
+        },
+        cryptoKeys: {
+            list: {
+                'us-central1': {
+                    err: err,
+                    data: data
+                }
+            },
+            getIamPolicy: {
+                'us-central1': {
+                    err: policyErr,
+                    data: policyData
+                }
+            }
+        }
+    }
+};
+
+describe('kmsPublicAccess', function () {
+    describe('run', function () {
+        it('should give unknown result if unable to query cryptographic keys', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query cryptographic keys');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                ['error'],
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no cryptographic keys found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No cryptographic keys found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null,
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give unknown if unable to query IAM Policies for cryptographic keys', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query IAM Policies for Cryptographic Keys');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                cryptoKeys,
+                null,
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no IAM Policies found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No IAM Policies found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                cryptoKeys,
+                null,
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if crypto key is publicly accessible', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Cryptographic Key is publicly accessible');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [cryptoKeys[0]],
+                null,
+                [keyPolicies[0]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no IAM policies are found for cryptographic key', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No IAM Policies found for cryptographic key');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [cryptoKeys[2]],
+                null,
+                [keyPolicies],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if cryptographic key is not publicly accessible', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Cryptographic Key is not publicly accessible');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [cryptoKeys[1]],
+                null,
+                [keyPolicies[1]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+    })
+});

--- a/plugins/google/dataproc/dataprocClusterEncryption.js
+++ b/plugins/google/dataproc/dataprocClusterEncryption.js
@@ -1,0 +1,111 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataproc Cluster Encryption',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that Dataproc clusters have encryption enabled using desired protection level.',
+    more_info: 'By default, all dataproc clusters are encrypted using Google-managed keys. To have better control over how your dataproc clusters are encrypted, you can use Customer-Managed Keys (CMKs).',
+    link: 'https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/customer-managed-encryption',
+    recommended_action: 'Ensure that all Dataproc clusters have desired encryption level.',
+    apis: ['clusters:dataproc:list', 'keyRings:list', 'cryptoKeys:list'],
+    settings: {
+        dataproc_cluster_encryption_level: {
+            name: 'Dataproc Cluster Encryption Level',
+            description: 'Desired protection level for Dataproc clusters. default: google-managed, cloudcmek: customer managed encryption keys, ' +
+                'cloudhsm: customer managed HSM encryption key, external: imported or externally managed key',
+            regex: '^(default|cloudcmek|cloudhsm|external)$',
+            default: 'cloudcmek'
+        }
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let desiredEncryptionLevelStr = settings.dataproc_cluster_encryption_level || this.settings.dataproc_cluster_encryption_level.default;
+        var desiredEncryptionLevel = helpers.PROTECTION_LEVELS.indexOf(desiredEncryptionLevelStr);
+
+        var keysObj = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.series([
+            function(cb) {
+                async.each(regions.cryptoKeys, function(region, rcb) {
+                    let cryptoKeys = helpers.addSource(
+                        cache, source, ['cryptoKeys', 'list', region]);
+                    if (cryptoKeys && cryptoKeys.data && cryptoKeys.data.length) helpers.listToObj(keysObj, cryptoKeys.data, 'name');
+                    rcb();
+                }, function() {
+                    cb();
+                });
+            },
+            function(cb) {
+                async.each(regions.clusters.dataproc, function(region, rcb) {
+
+                    let clusters = helpers.addSource(
+                        cache, source, ['clusters', 'dataproc', 'list', region]);
+
+                    if (!clusters) return rcb();
+
+                    if (clusters.err || !clusters.data) {
+                        helpers.addResult(results, 3, 'Unable to query Dataproc clusters: ' + helpers.addError(clusters), region, null, null, clusters.err);
+                        return rcb();
+                    }
+
+                    if (!clusters.data.length) {
+                        helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                        return rcb();
+                    }
+                    
+                    if (clusters && clusters.data) {
+                        clusters.data.forEach(cluster => {
+                            if (!cluster.clusterName) return;
+
+                            let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+                            let currentEncryptionLevel;
+                           
+                            if (cluster && cluster.config && cluster.config.encryptionConfig && cluster.config.encryptionConfig.gcePdKmsKeyName
+                                && keysObj[cluster.config.encryptionConfig.gcePdKmsKeyName]) {
+                                currentEncryptionLevel = helpers.getProtectionLevel(keysObj[cluster.config.encryptionConfig.gcePdKmsKeyName], helpers.PROTECTION_LEVELS);
+                            } else {
+                                currentEncryptionLevel = 1; //default
+                            }
+
+                            let currentEncryptionLevelStr = helpers.PROTECTION_LEVELS[currentEncryptionLevel];
+
+                            if (currentEncryptionLevel >= desiredEncryptionLevel) {
+                                helpers.addResult(results, 0,
+                                    `Dataproc cluster has encryption level ${currentEncryptionLevelStr} which is greater than or equal to ${desiredEncryptionLevelStr}`,
+                                    region, resource);
+                            } else {
+                                helpers.addResult(results, 2,
+                                    `Dataproc cluster has encryption level ${currentEncryptionLevelStr} which is less than ${desiredEncryptionLevelStr}`,
+                                    region, resource);
+                            }
+                        });
+                    }
+                    
+                    rcb();
+                }, function() {
+                    cb();
+                });
+            }
+        ], function() {
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/dataprocClusterEncryption.spec.js
+++ b/plugins/google/dataproc/dataprocClusterEncryption.spec.js
@@ -1,0 +1,155 @@
+var expect = require('chai').expect;
+var plugin = require('./dataprocClusterEncryption');
+
+const cryptoKeys = [
+    {
+        name: "projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-2",
+        primary: {
+            name: "projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-1/cryptoKeyVersions/1",
+            state: "DESTROYED",
+            createTime: "2021-06-17T08:01:36.739860492Z",
+            destroyEventTime: "2021-06-18T11:17:00.798768Z",
+            protectionLevel: "SOFTWARE",
+            algorithm: "GOOGLE_SYMMETRIC_ENCRYPTION",
+            generateTime: "2021-06-17T08:01:36.739860492Z",
+        },
+        purpose: "ENCRYPT_DECRYPT",
+        createTime: "2021-06-17T08:01:36.739860492Z",
+        nextRotationTime: "2021-09-14T19:00:00Z",
+        rotationPeriod: "7776000s",
+        versionTemplate: {
+            protectionLevel: "SOFTWARE",
+            algorithm: "GOOGLE_SYMMETRIC_ENCRYPTION",
+        },
+    }
+];
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        config: {
+            encryptionConfig: {
+                gcePdKmsKeyName: 'projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-2'
+            }
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        config: {
+            securityConfig: { kerberosConfig: {} },
+            endpointConfig: {}
+        },
+        labels: {}
+    },
+];
+
+const createCache = (err, data, keysList, keysErr) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        cryptoKeys: {
+            list: {
+                'global': {
+                    err: keysErr,
+                    data: keysList
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dataprocClusterEncryption', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if no dataproc clusters found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [],
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if cluster has desired encryption level', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('which is greater than or equal to');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [clusters[0]],
+                cryptoKeys,
+                null
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if cluster does not have desired encryption level', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('which is less than');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [clusters[1]],
+                cryptoKeys,
+                null
+            );
+            plugin.run(cache, {}, callback);
+        });
+    })
+});

--- a/plugins/google/dataproc/dataprocClusterLabelsAdded.js
+++ b/plugins/google/dataproc/dataprocClusterLabelsAdded.js
@@ -1,0 +1,67 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataproc Cluster Labels Added',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that all Dataproc clusters have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/dataproc/docs/guides/creating-managing-labels',
+    recommended_action: 'Ensure labels are added to all Dataproc clusters.',
+    apis: ['dataproc:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.clusters.dataproc, function(region, rcb){
+            let clusters = helpers.addSource(cache, source,
+                ['clusters', 'dataproc' ,'list', region]);
+
+            if (!clusters) return rcb();
+
+            if (clusters.err || !clusters.data) {
+                helpers.addResult(results, 3, 'Unable to query Dataproc clusters', region, null, null, clusters.err);
+                return rcb();
+            }
+
+            if (!clusters.data.length) {
+                helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                return rcb();
+            }
+
+            clusters.data.forEach(cluster => {
+                if (!cluster.clusterName) return;
+
+                let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+
+                if (cluster.labels &&
+                    Object.keys(cluster.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(cluster.labels).length} labels found for Dataproc cluster`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Dataproc cluster does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/dataprocClusterLabelsAdded.spec.js
+++ b/plugins/google/dataproc/dataprocClusterLabelsAdded.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./dataprocClusterLabelsAdded');
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        labels: {
+            'goog-dataproc-cluster-name': 'cluster-bd18',
+            'goog-dataproc-cluster-uuid': '090e0094-dfb8-4d21-944c-d452452e528f',
+            'goog-dataproc-location': 'us-central1'
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        labels: {}
+    },
+];
+
+const createCache = (err, data) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dataprocClusterLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no clusters are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Dataproc cluster');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Dataproc cluster does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/dataproc/hadoopSecureModeEnabled.js
+++ b/plugins/google/dataproc/hadoopSecureModeEnabled.js
@@ -1,0 +1,68 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Hadoop Secure Mode Enabled',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that all Dataproc clusters have hadoop secure mode enabled.',
+    more_info: 'Enabling Hadoop secure mode will allow multi-tenancy with security features like isolation, encryption, and user authentication within the cluster. It also enforces all Hadoop services and users to be authenticated via Kerberos Key distribution.',
+    link: 'https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/security',
+    recommended_action: 'Enable Hadoop secure mode for all Dataproc clusters.',
+    apis: ['clusters:dataproc:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.clusters.dataproc, function(region, rcb){
+            let clusters = helpers.addSource(cache, source,
+                ['clusters', 'dataproc' ,'list', region]);
+
+            if (!clusters) return rcb();
+
+            if (clusters.err || !clusters.data) {
+                helpers.addResult(results, 3, 'Unable to query Dataproc clusters', region, null, null, clusters.err);
+                return rcb();
+            }
+
+            if (!clusters.data.length) {
+                helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                return rcb();
+            }
+
+            clusters.data.forEach(cluster => {
+
+                if (!cluster.clusterName) return;
+
+                let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+
+                if (cluster.config && cluster.config.securityConfig
+                        && cluster.config.securityConfig.kerberosConfig && cluster.config.securityConfig.kerberosConfig.enableKerberos) {
+                    helpers.addResult(results, 0,
+                        'Hadoop Secure mode is enabled for Dataproc cluster', region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Hadoop Secure mode is not enabled for Dataproc cluster', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/hadoopSecureModeEnabled.spec.js
+++ b/plugins/google/dataproc/hadoopSecureModeEnabled.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./hadoopSecureModeEnabled');
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        config: {
+            securityConfig: {
+                kerberosConfig: {enableKerberos: true}
+            }
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        labels: {}
+    },
+];
+
+const createCache = (err, data) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('hadoopSecureModeEnabled', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no clusters are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if hadoop secure mode is enabled for the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Hadoop Secure mode is enabled');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if hadoop secure mode is not enabled for the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Hadoop Secure mode is not enabled');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/dns/dnsZoneLabelsAdded.js
+++ b/plugins/google/dns/dnsZoneLabelsAdded.js
@@ -1,0 +1,66 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'DNS Zone Labels Added',
+    category: 'DNS',
+    domain: 'Content Delivery',
+    description: 'Ensure Cloud DNS zones have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/dns/docs/zones',
+    recommended_action: 'Ensure labels are added for all managed zones in the cloud DNS service.',
+    apis: ['managedZones:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.managedZones, function(region, rcb){
+            let managedZones = helpers.addSource(cache, source,
+                ['managedZones', 'list', region]);
+
+            if (!managedZones) return rcb();
+
+            if (managedZones.err || !managedZones.data) {
+                helpers.addResult(results, 3, 'Unable to query DNS managed zones: ' + helpers.addError(managedZones), region, null, null, managedZones.err);
+                return rcb();
+            }
+
+            if (!managedZones.data.length) {
+                helpers.addResult(results, 0, 'No DNS managed zones found', region);
+                return rcb();
+            }
+
+            managedZones.data.forEach(managedZone => {
+                let resource = helpers.createResourceName('zones', managedZone.name, project);
+           
+                if (managedZone.labels &&
+                    Object.keys(managedZone.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(managedZone.labels).length} labels found for DNS managed zone`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'DNS managed zone does not have any labels', region, resource);
+                }
+
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dns/dnsZoneLabelsAdded.spec.js
+++ b/plugins/google/dns/dnsZoneLabelsAdded.spec.js
@@ -1,0 +1,124 @@
+var expect = require('chai').expect;
+var plugin = require('./dnsZoneLabelsAdded');
+
+const createCache = (err, data) => {
+    return {
+        managedZones: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dnsZoneLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a managed zone error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query DNS managed zones');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if no managed zone records are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No DNS managed zones found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if the managed zone has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for DNS managed zone');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [
+                    {
+                        "name": "giotestdnszone1",
+                        "dnsName": "cloudsploit.com.",
+                        "description": "",
+                        "id": "4534388710135378441",
+                        "nameServers": [
+                            "ns-cloud-e1.googledomains.com.",
+                            "ns-cloud-e2.googledomains.com.",
+                            "ns-cloud-e3.googledomains.com.",
+                            "ns-cloud-e4.googledomains.com."
+                        ],
+                        "creationTime": "2019-10-03T21:11:18.894Z",
+                        "labels": {"test": "test"},
+                        "visibility": "public",
+                        "kind": "dns#managedZone"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if the managed zone does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [
+                    {
+                        "name": "giotestdnszone1",
+                        "dnsName": "cloudsploit.com.",
+                        "description": "",
+                        "id": "4534388710135378441",
+                        "nameServers": [
+                            "ns-cloud-e1.googledomains.com.",
+                            "ns-cloud-e2.googledomains.com.",
+                            "ns-cloud-e3.googledomains.com.",
+                            "ns-cloud-e4.googledomains.com."
+                        ],
+                        "creationTime": "2019-10-03T21:11:18.894Z",
+                        "visibility": "public",
+                        "kind": "dns#managedZone"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+});

--- a/plugins/google/kubernetes/aliasIpRangesEnabled.js
+++ b/plugins/google/kubernetes/aliasIpRangesEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Alias IP ranges allow users to assign ranges of internal IP addresses as alias to a network interface.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/',
     recommended_action: 'Ensure that Kubernetes clusters have alias IP ranges enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/aliasIpRangesEnabled.spec.js
+++ b/plugins/google/kubernetes/aliasIpRangesEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./aliasIpRangesEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/autoNodeRepairEnabled.js
+++ b/plugins/google/kubernetes/autoNodeRepairEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'When automatic repair on nodes is enabled, the Kubernetes engine performs health checks on all nodes, automatically repairing nodes that fail health checks. This ensures that the Kubernetes environment stays optimal.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair',
     recommended_action: 'Ensure that automatic node repair is enabled on all node pools in Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/autoNodeRepairEnabled.spec.js
+++ b/plugins/google/kubernetes/autoNodeRepairEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./autoNodeRepairEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/autoNodeUpgradesEnabled.js
+++ b/plugins/google/kubernetes/autoNodeUpgradesEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Enabling automatic upgrades on nodes ensures that each node stays current with the latest version of the master branch, also ensuring that the latest security patches are installed to provide the most secure environment.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades',
     recommended_action: 'Ensure that automatic node upgrades are enabled on all node pools in Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/autoNodeUpgradesEnabled.spec.js
+++ b/plugins/google/kubernetes/autoNodeUpgradesEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./autoNodeUpgradesEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/basicAuthenticationDisabled.js
+++ b/plugins/google/kubernetes/basicAuthenticationDisabled.js
@@ -10,7 +10,7 @@ module.exports = {
         'the recommended method to authenticate into the Kubernetes API server.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster',
     recommended_action: 'Disable basic authentication on all clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -28,9 +28,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/basicAuthenticationDisabled.spec.js
+++ b/plugins/google/kubernetes/basicAuthenticationDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./basicAuthenticationDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterEncryption.js
+++ b/plugins/google/kubernetes/clusterEncryption.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Application-layer secrets encryption adds additional security layer to sensitive data such as Kubernetes secrets stored in etcd.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets',
     recommended_action: 'Ensure that all GKE clusters have the desired application-layer secrets encryption level.',
-    apis: ['clusters:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['clusters:kubernetes:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         kubernetes_cluster_encryption_level: {
             name: 'Kubernetes Cluster Encryption Protection Level',
@@ -54,9 +54,9 @@ module.exports = {
                 });
             },
             function(cb) {
-                async.each(regions.clusters, function(region, rcb) {
+                async.each(regions.clusters.kubernetes, function(region, rcb) {
                     let clusters = helpers.addSource(cache, source,
-                        ['clusters', 'list', region]);
+                        ['clusters', 'kubernetes', 'list', region]);
 
                     if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterEncryption.spec.js
+++ b/plugins/google/kubernetes/clusterEncryption.spec.js
@@ -66,10 +66,12 @@ const clusters = [
 const createCache = (clustersList, clusterError, keysList, keysErr) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: clusterError,
-                    data: clustersList
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: clusterError,
+                        data: clustersList
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterLabelsAdded.js
+++ b/plugins/google/kubernetes/clusterLabelsAdded.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to add labels to Kubernetes clusters to apply specific security settings and auto configure objects at creation.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels',
     recommended_action: 'Ensure labels are added to Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterLabelsAdded.spec.js
+++ b/plugins/google/kubernetes/clusterLabelsAdded.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./clusterLabelsAdded');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterLeastPrivilege.js
+++ b/plugins/google/kubernetes/clusterLeastPrivilege.js
@@ -10,7 +10,7 @@ module.exports = {
         'Kubernetes default service account should be limited to minimal access scopes necessary to operate the clusters.',
     link: 'https://cloud.google.com/compute/docs/access/service-accounts',
     recommended_action: 'Ensure that all Kubernetes clusters are created with minimal access scope.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -28,10 +28,10 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
 
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterLeastPrivilege.spec.js
+++ b/plugins/google/kubernetes/clusterLeastPrivilege.spec.js
@@ -4,9 +4,11 @@ var plugin = require('./clusterLeastPrivilege');
 const createCache = (clusterData) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    data: clusterData
+            kubernetes: {
+                list: {
+                    'global': {
+                        data: clusterData
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/cosImageEnabled.js
+++ b/plugins/google/kubernetes/cosImageEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Container-Optimized OS is optimized to enhance node security. It is backed by a team at Google that can quickly patch it.',
     link: 'https://cloud.google.com/container-optimized-os/',
     recommended_action: 'Enable Container-Optimized OS on all Kubernetes cluster nodes',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/cosImageEnabled.spec.js
+++ b/plugins/google/kubernetes/cosImageEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./cosImageEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/defaultServiceAccount.js
+++ b/plugins/google/kubernetes/defaultServiceAccount.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes cluster nodes should use customized service accounts that have minimal privileges to run. This reduces the attack surface in the case of a malicious attack on the cluster.',
     link: 'https://cloud.google.com/container-optimized-os/',
     recommended_action: 'Ensure that no Kubernetes cluster nodes are using the default service account',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/defaultServiceAccount.spec.js
+++ b/plugins/google/kubernetes/defaultServiceAccount.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./defaultServiceAccount');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/integrityMonitoringEnabled.js
+++ b/plugins/google/kubernetes/integrityMonitoringEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Integrity Monitoring feature automatically monitors the integrity of your cluster nodes.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#integrity_monitoring',
     recommended_action: 'Enable Integrity Monitoring feature for your cluster nodes',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/integrityMonitoringEnabled.spec.js
+++ b/plugins/google/kubernetes/integrityMonitoringEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./integrityMonitoringEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/kubernetesAlphaDisabled.js
+++ b/plugins/google/kubernetes/kubernetesAlphaDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to not use Alpha clusters as they expire after thirty days and do not receive security updates.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/concepts/alpha-clusters',
     recommended_action: '1. Create a new cluster with the alpha feature disabled. 2. Migrate all required cluster data from the cluster with alpha to this newly created cluster. 3.Delete the engine cluster with alpha enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/kubernetesAlphaDisabled.spec.js
+++ b/plugins/google/kubernetes/kubernetesAlphaDisabled.spec.js
@@ -4,10 +4,12 @@ var plugin = require('./kubernetesAlphaDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/legacyAuthorizationDisabled.js
+++ b/plugins/google/kubernetes/legacyAuthorizationDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'The legacy authorizer in Kubernetes grants broad, statically defined permissions.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster',
     recommended_action: 'Disable legacy authorization on all clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/legacyAuthorizationDisabled.spec.js
+++ b/plugins/google/kubernetes/legacyAuthorizationDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./legacyAuthorizationDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/loggingEnabled.js
+++ b/plugins/google/kubernetes/loggingEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'This setting should be enabled to ensure Kubernetes control plane logs are properly recorded.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/legacy-stackdriver/logging',
     recommended_action: 'Ensure that logging is enabled on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
     compliance: {
         hipaa: 'HIPAA requires the logging of all activity ' +
             'including access and all actions taken.'
@@ -31,9 +31,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/loggingEnabled.spec.js
+++ b/plugins/google/kubernetes/loggingEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./loggingEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/masterAuthorizedNetwork.js
+++ b/plugins/google/kubernetes/masterAuthorizedNetwork.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Authorized networks are a way of specifying a restricted range of IP addresses that are permitted to access your container clusters Kubernetes master endpoint.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/authorized-networks',
     recommended_action: 'Enable master authorized networks on all clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/masterAuthorizedNetwork.spec.js
+++ b/plugins/google/kubernetes/masterAuthorizedNetwork.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./masterAuthorizedNetwork');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/monitoringEnabled.js
+++ b/plugins/google/kubernetes/monitoringEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes supports monitoring through Stackdriver.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/',
     recommended_action: 'Ensure monitoring is enabled on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/monitoringEnabled.spec.js
+++ b/plugins/google/kubernetes/monitoringEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./monitoringEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/networkPolicyEnabled.js
+++ b/plugins/google/kubernetes/networkPolicyEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes network policy creates isolation between cluster pods, this creates a more secure environment with only specified connections allowed.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy',
     recommended_action: 'Enable network policy on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/networkPolicyEnabled.spec.js
+++ b/plugins/google/kubernetes/networkPolicyEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./networkPolicyEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/nodeEncryption.js
+++ b/plugins/google/kubernetes/nodeEncryption.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Using Customer Managed Keys (CMKs) gives you better control over the encryption/decryption process of your cluster nodes.',
     link: 'https://cloud.google.com/security/encryption/default-encryption',
     recommended_action: 'Ensure that all node pools in GKE clusters have the desired encryption level.',
-    apis: ['clusters:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['clusters:kubernetes:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         kubernetes_node_encryption_level: {
             name: 'Kubernetes Node Encryption Protection Level',
@@ -56,9 +56,9 @@ module.exports = {
                 });
             },
             function(cb) {
-                async.each(regions.clusters, function(region, rcb) {
+                async.each(regions.clusters.kubernetes, function(region, rcb) {
                     let clusters = helpers.addSource(cache, source,
-                        ['clusters', 'list', region]);
+                        ['clusters', 'kubernetes', 'list', region]);
 
                     if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/nodeEncryption.spec.js
+++ b/plugins/google/kubernetes/nodeEncryption.spec.js
@@ -75,10 +75,12 @@ const clusters = [
 const createCache = (clustersList, clusterError, keysList, keysErr) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: clusterError,
-                    data: clustersList
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: clusterError,
+                        data: clustersList
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/podSecurityPolicyEnabled.js
+++ b/plugins/google/kubernetes/podSecurityPolicyEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes pod security policy is a resource that controls security sensitive aspects of the pod configuration.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies',
     recommended_action: 'Ensure that all Kubernetes clusters have pod security policy enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/podSecurityPolicyEnabled.spec.js
+++ b/plugins/google/kubernetes/podSecurityPolicyEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./podSecurityPolicyEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/privateClusterEnabled.js
+++ b/plugins/google/kubernetes/privateClusterEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes private clusters only have internal ip ranges, which ensures that their workloads are isolated from the public internet.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters',
     recommended_action: 'Ensure that all Kubernetes clusters have private cluster enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/privateClusterEnabled.spec.js
+++ b/plugins/google/kubernetes/privateClusterEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./privateClusterEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/privateEndpoint.js
+++ b/plugins/google/kubernetes/privateEndpoint.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'kubernetes private endpoints can be used to route all traffic between the Kubernetes worker and control plane nodes over a private VPC endpoint rather than across the public internet.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters',
     recommended_action: 'Enable the private endpoint setting for all GKE clusters when creating the cluster.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/privateEndpoint.spec.js
+++ b/plugins/google/kubernetes/privateEndpoint.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./privateEndpoint');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/secureBootEnabled.js
+++ b/plugins/google/kubernetes/secureBootEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Secure Boot feature protects your cluster nodes from malware and makes sure the system runs only authentic software.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot',
     recommended_action: 'Ensure that Secure Boot feature is enabled for all node pools in your GKE clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/secureBootEnabled.spec.js
+++ b/plugins/google/kubernetes/secureBootEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./secureBootEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/shieldedNodes.js
+++ b/plugins/google/kubernetes/shieldedNodes.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Shielded GKE nodes give strong cryptographic identity. This prevents attackers from being able to impersonate a node in your GKE cluster even if the attacker can extract the node credentials.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes',
     recommended_action: 'Ensure that shielded nodes setting is enabled in your GKE cluster',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
    
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/shieldedNodes.spec.js
+++ b/plugins/google/kubernetes/shieldedNodes.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./shieldedNodes');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/webDashboardDisabled.js
+++ b/plugins/google/kubernetes/webDashboardDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to disable the web dashboard because it is backed by a highly privileged service account.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards',
     recommended_action: 'Ensure that no Kubernetes clusters have the web dashboard enabled',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/webDashboardDisabled.spec.js
+++ b/plugins/google/kubernetes/webDashboardDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./webDashboardDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/logging/auditConfigurationLogging.js
+++ b/plugins/google/logging/auditConfigurationLogging.js
@@ -56,14 +56,15 @@ module.exports = {
             var metricExists = false;
             var metricName = '';
 
-            var testMetrics = 'protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*';
+            var testMetrics = 'protoPayload.methodName=SetIamPolicy AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*';
 
 
             metrics.data.forEach(metric => {
                 if (metric.filter) {
                     if (metricExists) return;
 
-                    if (metric.filter === testMetrics) {
+                    var metricFilter = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']/g, '').replace(/\s+/g, ' ').trim();
+                    if (metricFilter === testMetrics) {
                         metricExists = true;
                         metricName = metric.metricDescriptor.type;
                     } else {

--- a/plugins/google/logging/customRoleLogging.js
+++ b/plugins/google/logging/customRoleLogging.js
@@ -55,7 +55,7 @@ module.exports = {
             var metricName = '';
 
             var testMetrics = [
-                'resource.type="iam_role" AND protoPayload.methodName="google.iam.admin.v1.CreateRole"',
+                'resource.type=iam_role AND protoPayload.methodName="google.iam.admin.v1.CreateRole"',
 
                 'protoPayload.methodName="google.iam.admin.v1.DeleteRole"',
                 'protoPayload.methodName="google.iam.admin.v1.UpdateRole"'
@@ -64,7 +64,8 @@ module.exports = {
             metrics.data.forEach(metric => {
                 if (metric.filter) {
                     if (metricExists) return;
-                    var checkMetrics = metric.filter.trim().split(' OR ');
+                    var metricFilter = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']iam_role["']/g, 'iam_role').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
+                    var checkMetrics = metricFilter.split(' OR ');
                     var missingMetrics = [];
 
                     testMetrics.forEach(testMetric => {

--- a/plugins/google/logging/projectOwnershipLogging.js
+++ b/plugins/google/logging/projectOwnershipLogging.js
@@ -60,15 +60,15 @@ module.exports = {
             var testMetrics = [
                 '(protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership',
                 'projectOwnerInvitee)',
-                '(protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")',
-                '(protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")'
+                '(protoPayload.serviceData.policyDelta.bindingDeltas.action=REMOVE AND protoPayload.serviceData.policyDelta.bindingDeltas.role=roles/owner)',
+                '(protoPayload.serviceData.policyDelta.bindingDeltas.action=ADD AND protoPayload.serviceData.policyDelta.bindingDeltas.role=roles/owner)'
             ];
 
             let disabled = false;
             for (let metric of metrics.data) {
                 if (metric.filter) {
                     if (metricExists) break;
-                    var checkMetrics = metric.filter.trim().replace(/\r|\n/g, '');
+                    var checkMetrics = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["'](ADD|REMOVE|roles\/owner)["']/g, '$1').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
                     var missingMetrics = [];
 
                     testMetrics.forEach(testMetric => {

--- a/plugins/google/logging/sqlConfigurationLogging.js
+++ b/plugins/google/logging/sqlConfigurationLogging.js
@@ -61,7 +61,7 @@ module.exports = {
                 if (metric.filter) {
                     if (metricExists) break;
 
-                    if (metric.filter.trim().indexOf(testMetrics) > -1) {
+                    if (metric.filter.replace(/'/g, '"').trim().indexOf(testMetrics) > -1) {
                         if (metric.disabled) disabled = true;
                         else {
                             disabled = false;

--- a/plugins/google/logging/storagePermissionsLogging.js
+++ b/plugins/google/logging/storagePermissionsLogging.js
@@ -65,7 +65,8 @@ module.exports = {
                 if (metric.filter) {
                     if (metricExists) break;
 
-                    if (metric.filter.trim() === testMetrics) {
+                    var metricFilter = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']gcs_bucket["']/g, 'gcs_bucket').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
+                    if (metricFilter === testMetrics) {
                         if (metric.disabled) disabled = true;
                         else {
                             disabled = false;

--- a/plugins/google/logging/vpcFirewallRuleLogging.js
+++ b/plugins/google/logging/vpcFirewallRuleLogging.js
@@ -55,15 +55,16 @@ module.exports = {
             var metricName = '';
 
             var testMetrics = [
-                'resource.type="gce_firewall_rule" AND protoPayload.methodName="v1.compute.firewalls.patch"',
-                'protoPayload.methodName="v1.compute.firewalls.insert"'
+                'resource.type=gce_firewall_rule AND protoPayload.methodName="v1.compute.firewalls.patch"',
+                'protoPayload.methodName="v1.compute.firewalls.insert"',
+                'protoPayload.methodName="v1.compute.firewalls.delete"'
             ];
 
             let disabled = false;
             for (let metric of metrics.data) {
                 if (metric.filter) {
                     if (metricExists) continue;
-                    var checkMetrics = metric.filter.trim().replace(/\r|\n/g, '');
+                    var checkMetrics = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']gce_firewall_rule["']/g, 'gce_firewall_rule').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
                     var missingMetrics = [];
                     testMetrics.forEach(testMetric => {
                         if (checkMetrics.indexOf(testMetric) === -1) {

--- a/plugins/google/logging/vpcNetworkLogging.js
+++ b/plugins/google/logging/vpcNetworkLogging.js
@@ -70,7 +70,7 @@ module.exports = {
             for (let metric of metrics.data) {
                 if (metric.filter) {
                     if (metricExists) continue;
-                    var checkMetrics = metric.filter.trim().replace(/\r|\n/g, '');
+                    var checkMetrics = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']gce_network["']/g, 'gce_network').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
                     var missingMetrics = [];
 
                     testMetrics.forEach(testMetric => {

--- a/plugins/google/logging/vpcNetworkRouteLogging.js
+++ b/plugins/google/logging/vpcNetworkRouteLogging.js
@@ -55,7 +55,7 @@ module.exports = {
             var metricName = '';
 
             var testMetrics = [
-                'resource.type="gce_route" AND protoPayload.methodName="beta.compute.routes.patch"',
+                'resource.type=gce_route AND protoPayload.methodName="beta.compute.routes.patch"',
                 'protoPayload.methodName="beta.compute.routes.insert"'
             ];
 
@@ -63,7 +63,7 @@ module.exports = {
             for (let metric of metrics.data) {
                 if (metric.filter) {
                     if (metricExists) continue;
-                    var checkMetrics = metric.filter.trim().replace(/\r|\n/g, '');
+                    var checkMetrics = metric.filter.replace(/\r?\n|\r/g, ' ').replace(/["']gce_route["']/g, 'gce_route').replace(/'/g, '"').replace(/\s+/g, ' ').trim();
                     var missingMetrics = [];
 
                     testMetrics.forEach(testMetric => {

--- a/plugins/google/pubsub/topicLabelsAdded.js
+++ b/plugins/google/pubsub/topicLabelsAdded.js
@@ -1,0 +1,52 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Topic Labels Added',
+    category: 'Pub/Sub',
+    domain: 'Application Integration',
+    description: 'Ensure that all Pub/Sub topics have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/pubsub/docs/labels',
+    recommended_action: 'Ensure labels are added to all Pub/Sub topics.',
+    apis: ['topics:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.topics, function(region, rcb){
+            let topics = helpers.addSource(cache, source,
+                ['topics', 'list', region]);
+
+            if (!topics) return rcb();
+
+            if (topics.err || !topics.data) {
+                helpers.addResult(results, 3, 'Unable to query Pub/Sub topics', region, null, null, topics.err);
+                return rcb();
+            }
+
+            if (!topics.data.length) {
+                helpers.addResult(results, 0, 'No Pub/Sub topics found', region);
+                return rcb();
+            }
+
+            topics.data.forEach(topic => {
+                if (topic.labels &&
+                    Object.keys(topic.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(topic.labels).length} labels found for Pub/Sub topic`, region, topic.name);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Pub/Sub topic does not have any labels', region, topic.name);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/pubsub/topicLabelsAdded.spec.js
+++ b/plugins/google/pubsub/topicLabelsAdded.spec.js
@@ -1,0 +1,97 @@
+var expect = require('chai').expect;
+var plugin = require('./topicLabelsAdded');
+
+const topics = [
+    {
+        name: 'projects/testproj/topics/topic-1',
+        labels: { label1: 'topic' },
+    },
+    {
+        name: 'projects/testproj/topics/topic-2'
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        topics: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        }
+    }
+};
+
+describe('topicLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a topic error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Pub/Sub topics');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no topics are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Pub/Sub topics found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the topic', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Pub/Sub topic');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [topics[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the topic', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Pub/Sub topic does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [topics[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/sql/mysqlLatestVersion.js
+++ b/plugins/google/sql/mysqlLatestVersion.js
@@ -1,0 +1,74 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'MySQL Latest Version',
+    category: 'SQL',
+    domain: 'Databases',
+    description: 'Ensure that MySQL database servers are using the latest major version of MySQL database.',
+    more_info: 'To make use of the latest database features and benefit from enhanced performance and security, make sure that your MySQL database instances are using the latest major version of MySQL.',
+    link: 'https://cloud.google.com/sql/docs/mysql/db-versions',
+    recommended_action: 'Ensure that all your MySQL database instances are using the latest MYSQL database version.',
+    apis: ['instances:sql:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, projects.err);
+            return callback(null, results, source);
+        }
+
+        let project = projects.data[0].name;
+
+        const latestMySQLVersion = 8.0;
+
+        async.each(regions.sql, function(region, rcb){
+            let sqlInstances = helpers.addSource(
+                cache, source, ['instances', 'sql', 'list', region]);
+
+            if (!sqlInstances) return rcb();
+
+            if (sqlInstances.err || !sqlInstances.data) {
+                helpers.addResult(results, 3, 'Unable to query SQL instances: ' + helpers.addError(sqlInstances), region);
+                return rcb();
+            }
+
+            if (!sqlInstances.data.length) {
+                helpers.addResult(results, 0, 'No SQL instances found', region);
+                return rcb();
+            }
+
+            sqlInstances.data.forEach(sqlInstance => {
+                if (sqlInstance.instanceType && sqlInstance.instanceType.toUpperCase() === 'READ_REPLICA_INSTANCE') return;
+
+                let resource = helpers.createResourceName('instances', sqlInstance.name, project);
+
+                if (sqlInstance.databaseVersion && !sqlInstance.databaseVersion.toLowerCase().includes('mysql')) {
+                    helpers.addResult(results, 0,
+                        'SQL instance database type is not of MySQL type', region, resource);
+                    return;
+                }
+
+                if (sqlInstance.databaseVersion && parseFloat(sqlInstance.databaseVersion.split('MYSQL_')[1].replace('_', '.')) >= latestMySQLVersion) {
+                    helpers.addResult(results, 0,
+                        `SQL instance is using MySQL major version ${sqlInstance.databaseVersion} which is the latest version`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        `SQL instance is using MySQL major version ${sqlInstance.databaseVersion} which is not the latest version`, region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/sql/mysqlLatestVersion.js
+++ b/plugins/google/sql/mysqlLatestVersion.js
@@ -29,7 +29,7 @@ module.exports = {
 
         const latestMySQLVersion = 8.0;
 
-        async.each(regions.sql, function(region, rcb){
+        async.each(regions.instances.sql, function(region, rcb){
             let sqlInstances = helpers.addSource(
                 cache, source, ['instances', 'sql', 'list', region]);
 

--- a/plugins/google/sql/mysqlLatestVersion.spec.js
+++ b/plugins/google/sql/mysqlLatestVersion.spec.js
@@ -1,0 +1,123 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var plugin = require('./mysqlLatestVersion');
+
+const createCache = (err, data) => {
+    return {
+        instances: {
+            sql: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [{ name: 'test-project' }]
+                }
+            }
+        }
+    }
+};
+
+describe('mysqlLatestVersion', function () {
+    describe('run', function () {
+        it('should give unknown result if a sql instance error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query SQL instances');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no sql instances are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No SQL instances found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if sql instance database type is not of MySQL type', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('SQL instance database type is not of MySQL type');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    name: "testing-instance",
+                    databaseVersion: "POSTGRES_13",
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if sql instance has the latest MySQL major version', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('which is the latest');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    instanceType: "CLOUD_SQL_INSTANCE",
+                    name: "testing-instance",
+                    databaseVersion: "MYSQL_8_2"
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if sql instance does not have the latest MySQL major version', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('which is not the latest version');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    instanceType: "CLOUD_SQL_INSTANCE",
+                    name: "testing-instance",
+                    databaseVersion: "MYSQL_5_7",
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+    })
+})

--- a/plugins/google/sql/postgresqlLatestVersion.js
+++ b/plugins/google/sql/postgresqlLatestVersion.js
@@ -1,0 +1,74 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'PostgreSQL Latest Version',
+    category: 'SQL',
+    domain: 'Databases',
+    description: 'Ensure that PostgreSQL database servers are using the latest major version of PostgreSQL database.',
+    more_info: 'To make use of the latest database features and benefit from enhanced performance and security, make sure that your PostgreSQL database instances are using the latest major version of PostgreSQL.',
+    link: 'https://cloud.google.com/sql/docs/postgres/db-versions',
+    recommended_action: 'Ensure that all your PostgreSQL database instances are using the latest PostgreSQL database version.',
+    apis: ['instances:sql:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, projects.err);
+            return callback(null, results, source);
+        }
+
+        let project = projects.data[0].name;
+
+        const latestPostgreSQLVersion = 14;
+
+        async.each(regions.instances.sql, function(region, rcb){
+            let sqlInstances = helpers.addSource(
+                cache, source, ['instances', 'sql', 'list', region]);
+
+            if (!sqlInstances) return rcb();
+
+            if (sqlInstances.err || !sqlInstances.data) {
+                helpers.addResult(results, 3, 'Unable to query SQL instances: ' + helpers.addError(sqlInstances), region);
+                return rcb();
+            }
+
+            if (!sqlInstances.data.length) {
+                helpers.addResult(results, 0, 'No SQL instances found', region);
+                return rcb();
+            }
+
+            sqlInstances.data.forEach(sqlInstance => {
+                if (sqlInstance.instanceType && sqlInstance.instanceType.toUpperCase() === 'READ_REPLICA_INSTANCE') return;
+
+                let resource = helpers.createResourceName('instances', sqlInstance.name, project);
+
+                if (sqlInstance.databaseVersion && !sqlInstance.databaseVersion.toUpperCase().startsWith('POSTGRES')) {
+                    helpers.addResult(results, 0,
+                        'SQL instance database type is not of POSTGRES type', region, resource);
+                    return;
+                }
+
+                if (sqlInstance.databaseVersion && parseInt(sqlInstance.databaseVersion.toUpperCase().split('POSTGRES_')[1]) >= latestPostgreSQLVersion) {
+                    helpers.addResult(results, 0,
+                        `SQL instance is using Postgres major version ${sqlInstance.databaseVersion} which is the latest version`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        `SQL instance is using Postgres major version ${sqlInstance.databaseVersion} which is not the latest version`, region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/sql/postgresqlLatestVersion.spec.js
+++ b/plugins/google/sql/postgresqlLatestVersion.spec.js
@@ -1,0 +1,123 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var plugin = require('./postgresqlLatestVersion');
+
+const createCache = (err, data) => {
+    return {
+        instances: {
+            sql: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [{ name: 'test-project' }]
+                }
+            }
+        }
+    }
+};
+
+describe('postgresqlLatestVersion', function () {
+    describe('run', function () {
+        it('should give unknown result if a sql instance error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query SQL instances');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no sql instances are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No SQL instances found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if sql instance database type is not of POSTGRES type', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('SQL instance database type is not of POSTGRES type');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    name: "testing-instance",
+                    databaseVersion: "MYSQL_5_7",
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if sql instance has the latest postgreSQL major version', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('which is the latest');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    instanceType: "CLOUD_SQL_INSTANCE",
+                    name: "testing-instance",
+                    databaseVersion: "POSTGRES_14"
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if sql instance does not have the latest PostgreSQL major version', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('which is not the latest version');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [{
+                    instanceType: "CLOUD_SQL_INSTANCE",
+                    name: "testing-instance",
+                    databaseVersion: "POSTGRES_11",
+                }],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+    })
+})

--- a/plugins/google/storage/bucketLabelsAdded.js
+++ b/plugins/google/storage/bucketLabelsAdded.js
@@ -1,0 +1,54 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Bucket Labels Added',
+    category: 'Storage',
+    domain: 'Storage',
+    description: 'Ensure that all Cloud Storage buckets have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/storage/docs/using-bucket-labels',
+    recommended_action: 'Ensure labels are added to all storage buckets.',
+    apis: ['buckets:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.buckets, function(region, rcb){
+            let buckets = helpers.addSource(cache, source,
+                ['buckets', 'list', region]);
+
+            if (!buckets) return rcb();
+
+            if (buckets.err || !buckets.data) {
+                helpers.addResult(results, 3, 'Unable to query storage buckets', region, null, null, buckets.err);
+                return rcb();
+            }
+
+            if (!buckets.data.length) {
+                helpers.addResult(results, 0, 'No storage buckets found', region);
+                return rcb();
+            }
+
+            buckets.data.forEach(bucket => {
+                let resource = helpers.createResourceName('b', bucket.name);
+
+                if (bucket.labels &&
+                    Object.keys(bucket.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(bucket.labels).length} labels found for storage bucket`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Storage bucket does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/storage/bucketLabelsAdded.spec.js
+++ b/plugins/google/storage/bucketLabelsAdded.spec.js
@@ -1,0 +1,103 @@
+var expect = require('chai').expect;
+var plugin = require('./bucketLabelsAdded');
+
+const buckets = [
+    {
+        kind: 'storage#bucket',
+        selfLink: 'https://www.googleapis.com/storage/v1/b/testproj-bucket-1',
+        id: 'testproj-bucket-1',
+        name: 'testproj-bucket-1',
+        labels: { bucket: 'label' },
+    },
+    {
+        kind: 'storage#bucket',
+        selfLink: 'https://www.googleapis.com/storage/v1/b/testproj-bucket-2',
+        id: 'testproj-bucket-2',
+        name: 'testproj-bucket-2'    
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        buckets: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        }
+    }
+};
+
+describe('bucketLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a bucket error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query storage buckets');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no buckets are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No storage buckets found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the bucket', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for storage bucket');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [buckets[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the bucket', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Storage bucket does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [buckets[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/vpcnetwork/openCassandraClient,js
+++ b/plugins/google/vpcnetwork/openCassandraClient,js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Cassandra Client',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP port 9042 for Cassandra Client is open to the public',
+    more_info: 'While some ports such as HTTP and HTTPS are required to be open to the public to function properly, more sensitive services such as Cassandra Client should be restricted to known IP addresses.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 9042 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [9042]
+            };
+
+            let service = 'Cassandra Client';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openCassandraClient.spec.js
+++ b/plugins/google/vpcnetwork/openCassandraClient.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openCassandraClient = require('./openCassandraClient');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "9042" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openCassandraClient', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openCassandraClient.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP port 9042 for Cassandra Client open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openCassandraClient.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openCassandraClient.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openCassandraClient.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openCassandraClient.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openCassandraInternode.js
+++ b/plugins/google/vpcnetwork/openCassandraInternode.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Cassandra Internode',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP port 7000 for Cassandra Internode is open to the public',
+    more_info: 'While some ports such as HTTP and HTTPS are required to be open to the public to function properly, more sensitive services such as Cassandra Internode should be restricted to known IP addresses.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 7000 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [7000]
+            };
+
+            let service = 'Cassandra Internode';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openCassandraInternode.spec.js
+++ b/plugins/google/vpcnetwork/openCassandraInternode.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openCassandraInternode = require('./openCassandraInternode');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "7000" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openCassandraInternode', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openCassandraInternode.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP port 7000 for Cassandra Internode open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openCassandraInternode.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openCassandraInternode.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openCassandraInternode.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openCassandraInternode.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openCassandraMonitoring.js
+++ b/plugins/google/vpcnetwork/openCassandraMonitoring.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Cassandra Monitoring',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP port 7199 for Cassandra Monitoring is open to the public',
+    more_info: 'While some ports such as HTTP and HTTPS are required to be open to the public to function properly, more sensitive services such as Cassandra Monitoring should be restricted to known IP addresses.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 7199 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [7199]
+            };
+
+            let service = 'Cassandra Monitoring';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openCassandraMonitoring.spec.js
+++ b/plugins/google/vpcnetwork/openCassandraMonitoring.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openCassandraMonitoring = require('./openCassandraMonitoring');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "7199" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openCassandraMonitoring', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openCassandraMonitoring.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP port 7199 for Cassandra Monitoring open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openCassandraMonitoring.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openCassandraMonitoring.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openCassandraMonitoring.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openCassandraMonitoring.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openCassandraThrift.js
+++ b/plugins/google/vpcnetwork/openCassandraThrift.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Cassandra Thrift',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP port 9160 for Cassandra Thrift is open to the public',
+    more_info: 'While some ports such as HTTP and HTTPS are required to be open to the public to function properly, more sensitive services such as Cassandra Thrift should be restricted to known IP addresses.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 9160 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [9160]
+            };
+
+            let service = 'Cassandra Thrift';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openCassandraThrift.spec.js
+++ b/plugins/google/vpcnetwork/openCassandraThrift.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openCassandraThrift = require('./openCassandraThrift');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "9160" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openCassandraThrift', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openCassandraThrift.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP port 9160 for Cassandra Thrift open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openCassandraThrift.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openCassandraThrift.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openCassandraThrift.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openCassandraThrift.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openElasticsearch.js
+++ b/plugins/google/vpcnetwork/openElasticsearch.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Elasticsearch',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP ports 9200, 9300 for Elasticsearch are open to the public',
+    more_info: 'Databases are the placeholders for most sensitive and confidential information in an organization. Allowing Inbound traffic from external IPv4 addresses to the database ports can lead to attacks like DoS, Brute Force, Smurf and reconnaissance. It is a best practice to block public access, and restrict the Inbound traffic from specific addresses and make the connection secure.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP ports 9200, 9300 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp' : [9200, 9300]
+            };
+
+            let service = 'Elasticsearch';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openElasticsearch.spec.js
+++ b/plugins/google/vpcnetwork/openElasticsearch.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openElasticsearch = require('./openElasticsearch');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "9200" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openElasticsearch', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openElasticsearch.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP ports 9200, 9300 open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openElasticsearch.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openElasticsearch.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openElasticsearch.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openElasticsearch.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openInternalWeb.js
+++ b/plugins/google/vpcnetwork/openInternalWeb.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Internal web',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if internal web port 8080 is open to the public',
+    more_info: 'Internal web port 8080 is used for web applications and proxy services. Allowing Inbound traffic from any IP address to TCP port 8080 is vulnerable to exploits like backdoor trojan attacks. It is a best practice to block port 8080 from the public internet.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 8080 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [8080]
+            };
+
+            let service = 'Internal Web';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openInternalWeb.spec.js
+++ b/plugins/google/vpcnetwork/openInternalWeb.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openInternalWeb = require('./openInternalWeb');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "8080" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openInternalWeb', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openInternalWeb.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has internal web port 8080 open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openInternalWeb.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openInternalWeb.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openInternalWeb.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openInternalWeb.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openLDAP.js
+++ b/plugins/google/vpcnetwork/openLDAP.js
@@ -1,0 +1,50 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open LDAP',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP or UDP port 389 for LDAP is open to the public',
+    more_info: 'Allowing Inbound traffic from external IPv4 addresses to LDAP ports can lead to attacks like DoS, Brute Force, Smurf, and reconnaissance. It is a best practice to restrict the Inbound traffic from specific addresses.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP and UDP port 389 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'udp' : [389],
+                'tcp' : [389]
+            };
+
+            let service = 'LDAP';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openLDAP.spec.js
+++ b/plugins/google/vpcnetwork/openLDAP.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openLDAP = require('./openLDAP');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "udp", "ports": [ "389" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openLDAP', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openLDAP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP or UDP port 389 is open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openLDAP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openLDAP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openLDAP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openLDAP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openLDAPS.js
+++ b/plugins/google/vpcnetwork/openLDAPS.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open LDAPS',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP port 636 for LDAP SSL is open to the public',
+    more_info: 'LDAP SSL port 636 is used for Secure LDAP authentication. Allowing Inbound traffic from any IP address to TCP port 636 is vulnerable to DoS attacks. It is a best practice to block port 636 from the public internet.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP port 636 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'tcp': [636]
+            };
+
+            let service = 'LDAPS';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openLDAPS.spec.js
+++ b/plugins/google/vpcnetwork/openLDAPS.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openLDAPS = require('./openLDAPS');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "636" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openLDAPS', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openLDAPS.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP port 636 for LDAP is open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openLDAPS.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openLDAPS.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openLDAPS.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openLDAPS.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openMemcached.js
+++ b/plugins/google/vpcnetwork/openMemcached.js
@@ -1,0 +1,50 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open Memcached',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if TCP or UDP port 11211 for Memcached is open to the public',
+    more_info: 'Memcached port 11211 is used for caching system and to reduce response times and the load on components. Allowing inbound traffic from any external IP address on memcached port is vulnerable to DoS attacks. It is a best practice to restrict access from specific IP addresses to port 11211.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict TCP and UDP port 11211 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'udp' : [11211],
+                'tcp' : [11211]
+            };
+
+            let service = 'Memcached';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openMemcached.spec.js
+++ b/plugins/google/vpcnetwork/openMemcached.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openMemcached = require('./openMemcached');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "udp", "ports": [ "11211" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openMemcached', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openMemcached.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has TCP or UDP port 11211 is open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openMemcached.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openMemcached.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openMemcached.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openMemcached.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/google/vpcnetwork/openSNMP.js
+++ b/plugins/google/vpcnetwork/openSNMP.js
@@ -1,0 +1,49 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Open SNMP',
+    category: 'VPC Network',
+    domain: 'Network Access Control',
+    description: 'Determines if UDP port 161 for SNMP is open to the public',
+    more_info: 'SNMP UDP 161 used by various devices and applications for logging events, monitoring and management. Allowing Inbound traffic from any external IP address on port 161 is vulnerable to  DoS attack. It is a best practice to block port 161 completely unless explicitly required.',
+    link: 'https://cloud.google.com/vpc/docs/using-firewalls',
+    recommended_action: 'Restrict UDP port 161 to known IP addresses.',
+    apis: ['firewalls:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.firewalls, function(region, rcb){
+            let firewalls = helpers.addSource(
+                cache, source, ['firewalls', 'list', region]);
+
+            if (!firewalls) return rcb();
+
+            if (firewalls.err || !firewalls.data) {
+                helpers.addResult(results, 3, 'Unable to query firewall rules', region, null, null, firewalls.err);
+                return rcb();
+            }
+
+            if (!firewalls.data.length) {
+                helpers.addResult(results, 0, 'No firewall rules found', region);
+                return rcb();
+            }
+
+            let ports = {
+                'udp': [161]
+            };
+
+            let service = 'SNMP';
+
+            helpers.findOpenPorts(firewalls.data, ports, service, region, results, cache, callback, source);
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/vpcnetwork/openSNMP.spec.js
+++ b/plugins/google/vpcnetwork/openSNMP.spec.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+const openSNMP = require('./openSNMP');
+
+const firewalls = [
+    {
+        "id": "4111718641158512144",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "openall",
+        "description": "Open All Ports",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "0.0.0.0/0" ],
+        "allowed": [{ "IPProtocol": "udp", "ports": [ "161" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/openall",
+        "kind": "compute#firewall"
+    },
+    {
+        "id": "3482752052453535354",
+        "creationTimestamp": "2021-02-25T00:34:07.519-08:00",
+        "name": "opensome",
+        "description": "",
+        "network": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/networks/app-vpc",
+        "priority": 1000,
+        "sourceRanges": [ "192.168.0.0/16" ],
+        "allowed": [{ "IPProtocol": "tcp", "ports": [ "22" ]}],
+        "direction": "INGRESS",
+        "disabled": false,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/aqua-dev-akhtar/global/firewalls/opensome",
+        "kind": "compute#firewall"
+    }
+];
+
+const createCache = (groups, err) => {
+    return {
+        firewalls:{
+            list: {
+                'global': {
+                    data: groups,
+                    err: err
+                },
+            },
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testProj'
+                }
+            }
+        }
+    };
+};
+
+const createNullCache = () => {
+    return {
+        firewalls:{
+            list: {
+                'global': null,
+            },
+        },
+    };
+};
+
+describe('openSNMP', function () {
+    describe('run', function () {
+        it('should PASS if no open ports found', function (done) {
+            const cache = createCache([firewalls[1]]);
+            openSNMP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should FAIL if firewall rule has UDP port 161 for SNMP is open to public', function (done) {
+            const cache = createCache([firewalls[0]]);
+            openSNMP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should PASS if no firewall rules found', function (done) {
+            const cache = createCache([]);
+            openSNMP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should UNKNWON if unable to describe firewall rules', function (done) {
+            const cache = createCache([], { message: 'Unable to query firewall rules'});
+            openSNMP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].region).to.equal('global');
+                done();
+            });
+        });
+
+        it('should not return anything if describe firewall rules response not found', function (done) {
+            const cache = createNullCache();
+            openSNMP.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
New GCP Rules - Cloudsploit - Part 2 (all rules with DOCs on Zanshin)
1 Bigquery rule
1 Bigtable rule
1 Cloud Function rule
4 Compute rules
3 Dataproc rules
1 DNS rule
1 Kubernetes rule
1 Pub/Sub rule
1 Storage rule

Correction for Bigquery rules --> duplicate entries resulting in duplicate alarms - removed
Updated collector.js with new collectors
Updated export.js with the new rules
Updated regions.js with the scopes for the new collectors
Change API call for Kubernetes collector and related rules
Minor correction in 1 SQL rule