### PR TITLE
AWS Plugins for New CIS-Benchmarks

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -9,9 +9,9 @@ module.exports = {
         'acmCertificateExpiry'          : require(__dirname + '/plugins/aws/acm/acmCertificateExpiry.js'),
         'acmSingleDomainNameCertificate': require(__dirname + '/plugins/aws/acm/acmSingleDomainNameCertificate.js'),
         'acmCertificateHasTags'         : require(__dirname + '/plugins/aws/acm/acmCertificateHasTags.js'),
-      
+
         'appmeshVGAccessLogging'        : require(__dirname + '/plugins/aws/appmesh/appmeshVGAccessLogging.js'),
-      
+
         'apigatewayCertificateRotation' : require(__dirname + '/plugins/aws/apigateway/apigatewayCertificateRotation.js'),
         'apigatewayCloudwatchLogs'      : require(__dirname + '/plugins/aws/apigateway/apigatewayCloudwatchLogs.js'),
         'apigatewayPrivateEndpoints'    : require(__dirname + '/plugins/aws/apigateway/apigatewayPrivateEndpoints.js'),
@@ -91,7 +91,7 @@ module.exports = {
         'cloudtrailS3Bucket'            : require(__dirname + '/plugins/aws/cloudtrail/cloudtrailS3Bucket.js'),
         'globalLoggingDuplicated'       : require(__dirname + '/plugins/aws/cloudtrail/globalLoggingDuplicated.js'),
         'cloudtrailNotificationsEnabled': require(__dirname + '/plugins/aws/cloudtrail/cloudtrailNotificationsEnabled.js'),
-        'cloudtrailHasTags'             : require(__dirname + '/plugins/aws/cloudtrail/cloudtrailHasTags.js'),       
+        'cloudtrailHasTags'             : require(__dirname + '/plugins/aws/cloudtrail/cloudtrailHasTags.js'),
 
         'ec2InstancesOptimized'         : require(__dirname + '/plugins/aws/computeoptimizer/ec2InstancesOptimized.js'),
         'lambdaFunctionsOptimized'      : require(__dirname + '/plugins/aws/computeoptimizer/lambdaFunctionsOptimized.js'),
@@ -106,7 +106,7 @@ module.exports = {
         'servicesInUse'                 : require(__dirname + '/plugins/aws/configservice/servicesInUse.js'),
 
         'devOpsGuruNotificationEnabled' : require(__dirname + '/plugins/aws/devopsguru/devOpsGuruNotificationEnabled.js'),
-       
+
         'dmsEncryptionEnabled'          : require(__dirname + '/plugins/aws/dms/dmsEncryptionEnabled.js'),
         'dmsPubliclyAccessibleInstances': require(__dirname + '/plugins/aws/dms/dmsPubliclyAccessibleInstances.js'),
         'dmsMultiAZFeatureEnabled'      : require(__dirname + '/plugins/aws/dms/dmsMultiAZFeatureEnabled.js'),
@@ -199,6 +199,7 @@ module.exports = {
         'webTierInstanceIamRole'        : require(__dirname + '/plugins/aws/ec2/webTierInstanceIamRole.js'),
         'vpnTunnelState'                : require(__dirname + '/plugins/aws/ec2/vpnTunnelState.js'),
         'networkAclOutboundTraffic'     : require(__dirname + '/plugins/aws/ec2/networkAclOutboundTraffic.js'),
+        'networkAclInboundTraffic'      : require(__dirname + '/plugins/aws/ec2/networkAclInboundTraffic.js'),
         'outdatedAmiInUse'              : require(__dirname + '/plugins/aws/ec2/outdatedAmiInUse.js'),
         'appTierInstanceIamRole'        : require(__dirname + '/plugins/aws/ec2/appTierInstanceIamRole.js'),
         'defaultSecurityGroup'          : require(__dirname + '/plugins/aws/ec2/defaultSecurityGroup.js'),
@@ -241,11 +242,11 @@ module.exports = {
         'eksSecurityGroups'             : require(__dirname + '/plugins/aws/eks/eksSecurityGroups.js'),
         'eksLatestPlatformVersion'      : require(__dirname + '/plugins/aws/eks/eksLatestPlatformVersion.js'),
         'eksClusterHasTags'             : require(__dirname + '/plugins/aws/eks/eksClusterHasTags.js'),
-      
+
         'kendraIndexEncrypted'          : require(__dirname + '/plugins/aws/kendra/kendraIndexEncrypted.js'),
-      
+
         'environmentTemplateEncrypted'  : require(__dirname + '/plugins/aws/proton/environmentTemplateEncrypted.js'),
-      
+
         'crosszoneLoadBalancing'        : require(__dirname + '/plugins/aws/elb/crosszoneLoadBalancing.js'),
         'insecureCiphers'               : require(__dirname + '/plugins/aws/elb/insecureCiphers.js'),
         'elbHttpsOnly'                  : require(__dirname + '/plugins/aws/elb/elbHttpsOnly.js'),
@@ -415,7 +416,8 @@ module.exports = {
         'bucketDnsCompliantName'        : require(__dirname + '/plugins/aws/s3/bucketDnsCompliantName.js'),
         'versionedBucketsLC'            : require(__dirname + '/plugins/aws/s3/versionedBucketsLC.js'),
         's3BucketHasTags'               : require(__dirname + '/plugins/aws/s3/s3BucketHasTags.js'),
-        
+        'bucketMFADeleteEnabled'              : require(__dirname + '/plugins/aws/s3/bucketMFADeleteEnabled.js'),
+
         'notebookDataEncrypted'         : require(__dirname + '/plugins/aws/sagemaker/notebookDataEncrypted.js'),
         'notebookDirectInternetAccess'  : require(__dirname + '/plugins/aws/sagemaker/notebookDirectInternetAccess.js'),
         'notebookInstanceInVpc'         : require(__dirname + '/plugins/aws/sagemaker/notebookInstanceInVpc.js'),
@@ -480,16 +482,16 @@ module.exports = {
         'mqDeploymentMode'              : require(__dirname + '/plugins/aws/mq/mqDeploymentMode.js'),
         'mqDesiredInstanceType'         : require(__dirname + '/plugins/aws/mq/mqDesiredInstanceType.js'),
         'mqBrokerEncrypted'             : require(__dirname + '/plugins/aws/mq/mqBrokerEncrypted.js'),
-      
+
         'memorydbClusterEncrypted'      : require(__dirname + '/plugins/aws/memorydb/memorydbClusterEncrypted.js'),
-      
+
         'mskClusterCBEncryption'        : require(__dirname + '/plugins/aws/msk/mskClusterCBEncryption.js'),
- 
+
         'mskClusterPublicAccess'        : require(__dirname + '/plugins/aws/msk/mskClusterPublicAccess.js'),
         'mskClusterUnauthAccess'        : require(__dirname + '/plugins/aws/msk/mskClusterUnauthAccess.js'),
         'mskClusterEncryptionAtRest'    : require(__dirname + '/plugins/aws/msk/mskClusterEncryptionAtRest.js'),
         'mskClusterEncryptionInTransit' : require(__dirname + '/plugins/aws/msk/mskClusterEncryptionInTransit.js'),
-      
+
         'auditLoggingEnabled'           : require(__dirname + '/plugins/aws/redshift/auditLoggingEnabled.js'),
         'redshiftClusterCmkEncrypted'   : require(__dirname + '/plugins/aws/redshift/redshiftClusterCmkEncrypted.js'),
         'redshiftEncryptionEnabled'     : require(__dirname + '/plugins/aws/redshift/redshiftEncryptionEnabled.js'),
@@ -504,9 +506,9 @@ module.exports = {
         'redshiftNodesCount'            : require(__dirname + '/plugins/aws/redshift/redshiftNodesCount.js'),
         'redshiftUnusedReservedNodes'   : require(__dirname + '/plugins/aws/redshift/redshiftUnusedReservedNodes.js'),
         'redshiftDesiredNodeType'       : require(__dirname + '/plugins/aws/redshift/redshiftDesiredNodeType.js'),
- 
+
         'redisClusterEncryptionAtRest'  : require(__dirname + '/plugins/aws/elasticache/redisClusterEncryptionAtRest.js'),
-        'reservedNodePaymentPending.js' : require(__dirname + '/plugins/aws/elasticache/reservedNodePaymentPending.js'),      
+        'reservedNodePaymentPending.js' : require(__dirname + '/plugins/aws/elasticache/reservedNodePaymentPending.js'),
         'unusedElastiCacheReservedNode' : require(__dirname + '/plugins/aws/elasticache/unusedElastiCacheReservedNode.js'),
         'reservedNodePaymentFailed'     : require(__dirname + '/plugins/aws/elasticache/reservedNodePaymentFailed.js'),
         'reservedNodeLeaseExpiration'   : require(__dirname + '/plugins/aws/elasticache/reservedNodeLeaseExpiration.js'),
@@ -547,7 +549,7 @@ module.exports = {
         'projectArtifactsEncrypted'     : require(__dirname + '/plugins/aws/codebuild/projectArtifactsEncrypted.js'),
 
         'codestarValidRepoProviders'    : require(__dirname + '/plugins/aws/codestar/codestarValidRepoProviders.js'),
-        
+
         'pipelineArtifactsEncrypted'    : require(__dirname + '/plugins/aws/codepipeline/pipelineArtifactsEncrypted.js'),
 
         'dataStoreEncrypted'            : require(__dirname + '/plugins/aws/healthlake/dataStoreEncrypted.js'),
@@ -560,11 +562,11 @@ module.exports = {
 
         'pipelineDataEncrypted'         : require(__dirname + '/plugins/aws/elastictranscoder/pipelineDataEncrypted.js'),
         'jobOutputsEncrypted'           : require(__dirname + '/plugins/aws/elastictranscoder/jobOutputsEncrypted.js'),
-      
+
         'translateJobOutputEncrypted'   : require(__dirname + '/plugins/aws/translate/translateJobOutputEncrypted.js'),
-      
+
         'databrewJobOutputEncrypted'    : require(__dirname + '/plugins/aws/gluedatabrew/databrewJobOutputEncrypted.js'),
-      
+
         'networkMemberDataEncrypted'    : require(__dirname + '/plugins/aws/managedblockchain/networkMemberDataEncrypted.js'),
 
         'docdbClusterEncrypted'         : require(__dirname + '/plugins/aws/documentDB/docdbClusterEncrypted.js'),
@@ -575,7 +577,7 @@ module.exports = {
         'instanceReportsEncrypted'      : require(__dirname + '/plugins/aws/connect/instanceReportsEncrypted.js'),
         'instanceCallRecordingEncrypted': require(__dirname + '/plugins/aws/connect/instanceCallRecordingEncrypted.js'),
         'instanceAttachmentsEncrypted'  : require(__dirname + '/plugins/aws/connect/instanceAttachmentsEncrypted.js'),
-        
+
         'backupVaultEncrypted'          : require(__dirname + '/plugins/aws/backup/backupVaultEncrypted.js'),
         'backupResourceProtection'      : require(__dirname + '/plugins/aws/backup/backupResourceProtection.js'),
         'backupInUseForRDSSnapshots'    : require(__dirname + '/plugins/aws/backup/backupInUseForRDSSnapshots.js'),
@@ -590,17 +592,17 @@ module.exports = {
 
         'trackerDataEncrypted'          : require(__dirname + '/plugins/aws/location/trackerDataEncrypted.js'),
         'geoCollectionDataEncrypted'    : require(__dirname + '/plugins/aws/location/geoCollectionDataEncrypted.js'),
-      
+
         'modelDataEncrypted'            : require(__dirname + '/plugins/aws/lookout/modelDataEncrypted.js'),
         'anomalyDetectorEncrypted'      : require(__dirname + '/plugins/aws/lookout/anomalyDetectorEncrypted.js'),
-      
+
         'lexAudioLogsEncrypted'         : require(__dirname + '/plugins/aws/lex/lexAudioLogsEncrypted.js'),
-  
+
         'forecastDatasetEncrypted'      : require(__dirname + '/plugins/aws/forecast/forecastDatasetEncrypted.js'),
         'datasetExportEncrypted'        : require(__dirname + '/plugins/aws/forecast/datasetExportEncrypted.js'),
 
         'fsxFileSystemEncrypted'        : require(__dirname + '/plugins/aws/fsx/fsxFileSystemEncrypted.js'),
-      
+
         'wafv2InUse'                    : require(__dirname + '/plugins/aws/wafv2/wafv2InUse.js'),
 
         'wafInUse'                      : require(__dirname + '/plugins/aws/waf/wafInUse.js'),
@@ -798,7 +800,7 @@ module.exports = {
         'advancedDataSecurityEnabled'   : require(__dirname + '/plugins/azure/sqlserver/advancedDataSecurityEnabled.js'),
         'tdeProtectorEncrypted'         : require(__dirname + '/plugins/azure/sqlserver/tdeProtectorEncrypted.js'),
         'noPublicAccess'                : require(__dirname + '/plugins/azure/sqlserver/noPublicAccess.js'),
-        'serverPrivateEndpoints'        : require(__dirname + '/plugins/azure/sqlserver/serverPrivateEndpoints.js'), 
+        'serverPrivateEndpoints'        : require(__dirname + '/plugins/azure/sqlserver/serverPrivateEndpoints.js'),
         'auditRetentionPolicy'          : require(__dirname + '/plugins/azure/sqlserver/auditRetentionPolicy.js'),
         'auditActionGroupsEnabled'      : require(__dirname + '/plugins/azure/sqlserver/auditActionGroupsEnabled.js'),
         'serverAuditingEnabled'         : require(__dirname + '/plugins/azure/sqlserver/serverAuditingEnabled.js'),
@@ -1171,7 +1173,7 @@ module.exports = {
 
         'apiKeyRotation'                : require(__dirname + '/plugins/google/api/apiKeyRotation.js'),
         'apiKeyApplicationRestriction'  : require(__dirname + '/plugins/google/api/apiKeyApplicationRestriction.js'),
-      
+
         'privateEndpoint'               : require(__dirname + '/plugins/google/kubernetes/privateEndpoint.js'),
         'monitoringEnabled'             : require(__dirname + '/plugins/google/kubernetes/monitoringEnabled.js'),
         'clusterLeastPrivilege'         : require(__dirname + '/plugins/google/kubernetes/clusterLeastPrivilege.js'),
@@ -1215,7 +1217,7 @@ module.exports = {
         'tablesCMKEncrypted'            : require(__dirname + '/plugins/google/bigquery/tablesCMKEncrypted.js'),
         'datasetLabelsAdded'            : require(__dirname + '/plugins/google/bigquery/datasetLabelsAdded.js'),
         'datasetsCMKEncrypted'          : require(__dirname + '/plugins/google/bigquery/datasetsCMKEncrypted.js'),
-      
+
         'topicEncryption'               : require(__dirname + '/plugins/google/pubsub/topicEncryption.js'),
         'deadLetteringEnabled'          : require(__dirname + '/plugins/google/pubsub/deadLetteringEnabled.js'),
         'topicLabelsAdded'              : require(__dirname + '/plugins/google/pubsub/topicLabelsAdded.js'),
@@ -1257,7 +1259,7 @@ module.exports = {
         'dataprocClusterLabelsAdded'    : require(__dirname + '/plugins/google/dataproc/dataprocClusterLabelsAdded.js'),
         'hadoopSecureModeEnabled'       : require(__dirname + '/plugins/google/dataproc/hadoopSecureModeEnabled.js'),
         'dataprocClusterEncryption'     : require(__dirname + '/plugins/google/dataproc/dataprocClusterEncryption.js'),
-        
+
         'bigtableInstanceLabelsAdded'   : require(__dirname + '/plugins/google/bigtable/bigtableInstanceLabelsAdded.js'),
 
         'assetInventoryEnabled'         : require(__dirname + '/plugins/google/serviceusage/assetInventoryEnabled.js'),
@@ -1278,7 +1280,7 @@ module.exports = {
         'passwordBlockLogon'            : require(__dirname + '/plugins/alibaba/ram/passwordBlockLogon.js'),
         'ramPolicyAttachments'          : require(__dirname + '/plugins/alibaba/ram/ramPolicyAttachments.js'),
         'ramAdminPolicy'                : require(__dirname + '/plugins/alibaba/ram/ramAdminPolicy.js'),
-      
+
         'openSSH'                       : require(__dirname + '/plugins/alibaba/ecs/openSSH.js'),
         'openRDP'                       : require(__dirname + '/plugins/alibaba/ecs/openRDP.js'),
         'openDNS'                       : require(__dirname + '/plugins/alibaba/ecs/openDNS.js'),
@@ -1305,7 +1307,7 @@ module.exports = {
         'openVNCServer'                 : require(__dirname + '/plugins/alibaba/ecs/openVNCServer.js'),
         'openAllPortsProtocols'         : require(__dirname + '/plugins/alibaba/ecs/openAllPortsProtocols.js'),
         'systemDisksEncrypted'          : require(__dirname + '/plugins/alibaba/ecs/systemDisksEncrypted.js'),
-      
+
         'bucketLoggingEnabled'          : require(__dirname + '/plugins/alibaba/oss/bucketLoggingEnabled.js'),
         'bucketPayByRequester'          : require(__dirname + '/plugins/alibaba/oss/bucketPayByRequester.js'),
         'ossBucketPrivate'              : require(__dirname + '/plugins/alibaba/oss/ossBucketPrivate.js'),
@@ -1314,10 +1316,10 @@ module.exports = {
         'ossBucketVersioning'           : require(__dirname + '/plugins/alibaba/oss/ossBucketVersioning.js'),
         'ossBucketTransferAcceleration' : require(__dirname + '/plugins/alibaba/oss/ossBucketTransferAcceleration.js'),
         'bucketCrossRegionReplication'  : require(__dirname + '/plugins/alibaba/oss/bucketCrossRegionReplication.js'),
-       
+
         'ossBucketIpRestriction'        : require(__dirname + '/plugins/alibaba/oss/ossBucketIpRestriction.js'),
         'ossBucketSecureTransport'      : require(__dirname + '/plugins/alibaba/oss/ossBucketSecureTransport.js'),
-      
+
         'rdsLogDuration'                : require(__dirname + '/plugins/alibaba/rds/rdsLogDuration.js'),
         'rdsSslEncryptionEnabled'       : require(__dirname + '/plugins/alibaba/rds/rdsSslEncryptionEnabled.js'),
         'rdsAuditingEnabled'            : require(__dirname + '/plugins/alibaba/rds/rdsAuditingEnabled.js'),
@@ -1329,7 +1331,7 @@ module.exports = {
 
         'actiontrailGlobalExportLogs'   : require(__dirname + '/plugins/alibaba/actiontrail/actiontrailGlobalExportLogs.js'),
         'actiontrailBucketPrivate'      : require(__dirname + '/plugins/alibaba/actiontrail/actiontrailBucketPrivate.js'),
-    
+
         'apiProtocol'                   : require(__dirname + '/plugins/alibaba/apigateway/apiProtocol.js'),
         'apiGroupTlsVersion'            : require(__dirname + '/plugins/alibaba/apigateway/apiGroupTlsVersion.js'),
         'networkPolicyEnabled'          : require(__dirname + '/plugins/alibaba/ack/networkPolicyEnabled.js'),

--- a/plugins/aws/cloudwatchlogs/monitoringMetrics.js
+++ b/plugins/aws/cloudwatchlogs/monitoringMetrics.js
@@ -57,6 +57,10 @@ var filterPatterns = [
     {
         name: 'VPC Changes',
         pattern: '{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }'
+    },
+    {
+        name: 'Organizations Changes',
+        pattern: '{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = AcceptHandshake) || ($.eventName = AttachPolicy) || ($.eventName = CreateAccount) || ($.eventName = CreateOrganizationalUnit) || ($.eventName = CreatePolicy) || ($.eventName = DeclineHandshake) || ($.eventName = DeleteOrganization) || ($.eventName = DeleteOrganizationalUnit) || ($.eventName = DeletePolicy) || ($.eventName = DetachPolicy) || ($.eventName = DisablePolicyType) || ($.eventName = EnablePolicyType) || ($.eventName = InviteAccountToOrganization) || ($.eventName = LeaveOrganization) || ($.eventName = MoveAccount) || ($.eventName = RemoveAccountFromOrganization) || ($.eventName = UpdatePolicy) || ($.eventName = UpdateOrganizationalUnit)) }'
     }
 ];
 
@@ -83,7 +87,7 @@ module.exports = {
                 ['cloudtrail', 'describeTrails', region]);
 
             if (!describeTrails) return rcb();
-            
+
             if (describeTrails.err || !describeTrails.data) {
                 helpers.addResult(results, 3,
                     `Unable to describe CloudTrail trails: ${helpers.addError(describeTrails)}`, region);

--- a/plugins/aws/ec2/networkAclInboundTraffic.js
+++ b/plugins/aws/ec2/networkAclInboundTraffic.js
@@ -1,0 +1,90 @@
+var async = require('async');
+var helpers = require('../../../helpers/aws');
+
+module.exports = {
+    title: 'Unrestricted Network ACL Inbound Traffic',
+    category: 'EC2',
+    domain: 'Compute',
+    description: 'Ensures that no Amazon Network ACL allows inbound/ingress traffic to remote administration ports.',
+    more_info: 'Amazon Network ACL should not allow inbound/ingress traffic to remote administration ports to avoid unauthorized access at the subnet level.',
+    recommended_action: 'Update Network ACL to allow inbound/ingress traffic to specific port ranges only',
+    link: 'https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html',
+    apis: ['EC2:describeNetworkAcls', 'STS:getCallerIdentity'],
+    compliance: {
+        cis1: '5.1 Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports',
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions(settings);
+
+        var acctRegion = helpers.defaultRegion(settings);
+        var awsOrGov = helpers.defaultPartition(settings);
+        var accountId = helpers.addSource(cache, source, ['sts', 'getCallerIdentity', acctRegion, 'data']);
+
+        async.each(regions.ec2, function(region, rcb){
+            var describeNetworkAcls = helpers.addSource(cache, source,
+                ['ec2', 'describeNetworkAcls', region]);
+
+            if (!describeNetworkAcls) return rcb();
+
+            if (describeNetworkAcls.err || !describeNetworkAcls.data) {
+                helpers.addResult(results, 3,
+                    `Unable to query for Network ACLs: ${helpers.addError(describeNetworkAcls)}`, region);
+                return rcb();
+            }
+
+            if (!describeNetworkAcls.data.length) {
+                helpers.addResult(results, 0,
+                    'No Network ACLs found', region);
+                return rcb();
+            }
+
+            describeNetworkAcls.data.forEach(acl =>{
+                var resource = `arn:${awsOrGov}:ec2:${region}:${accountId}:network-acl/${acl.NetworkAclId}`;
+                var unrestrictedAcl = false;
+
+                if (acl.Entries && acl.Entries.length) {
+                    for (var entry of acl.Entries) {
+                        if (!entry.Egress && disAllowedPorRange(entry.PortRange) && entry.RuleAction.toUpperCase() === 'ALLOW' && entry.CidrBlock==='0.0.0.0/0') {
+                            unrestrictedAcl = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!unrestrictedAcl) {
+                    helpers.addResult(results, 0,
+                        `Network ACL "${acl.NetworkAclId}" does not allow unrestricted access`,
+                        region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        `Network ACL "${acl.NetworkAclId}" allows unrestricted access`,
+                        region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            callback(null, results, source);
+        });
+    }
+};
+
+function disAllowedPorRange(range){
+    if (!range) {
+        return true;
+    } else if (22>=range.From && 22<=range.To){ //SSH
+        return true;
+    } else if (3389>=range.From && 3389<=range.To){  //RDP
+        return true;
+    } else if (80>=range.From && 80<=range.To){ // HTTP
+        return true;
+    } else if (443>=range.From && 443<=range.To){ //HTTPS
+        return true;
+    } else if (53>=range.From && 53 <=range.To){ //DNS
+        return true;
+    }
+    return false;
+}

--- a/plugins/aws/ec2/networkAclInboundTraffic.js
+++ b/plugins/aws/ec2/networkAclInboundTraffic.js
@@ -72,19 +72,14 @@ module.exports = {
     }
 };
 
-function disAllowedPorRange(range){
-    if (!range) {
-        return true;
-    } else if (22>=range.From && 22<=range.To){ //SSH
-        return true;
-    } else if (3389>=range.From && 3389<=range.To){  //RDP
-        return true;
-    } else if (80>=range.From && 80<=range.To){ // HTTP
-        return true;
-    } else if (443>=range.From && 443<=range.To){ //HTTPS
-        return true;
-    } else if (53>=range.From && 53 <=range.To){ //DNS
-        return true;
+function disAllowedPorRange(range) {
+    const allowedPorts = [22, 3389, 80, 443, 53];
+
+    if (!range) return true;
+
+    for (const port of allowedPorts) {
+        if (port >= range.From && port <= range.To) return true;
     }
+
     return false;
 }

--- a/plugins/aws/ec2/networkAclInboundTraffic.spec.js
+++ b/plugins/aws/ec2/networkAclInboundTraffic.spec.js
@@ -1,0 +1,189 @@
+var expect = require('chai').expect;
+const networkAclInboundTraffic = require('./networkAclInboundTraffic');
+
+const describeNetworkAcls = [
+    {
+        "Associations": [
+            {
+                "NetworkAclAssociationId": "aclassoc-3ddddf7f",
+                "NetworkAclId": "acl-65603818",
+                "SubnetId": "subnet-06aa0f60"
+            }
+        ],
+        "Entries": [
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": false,
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100,
+                "PortRange": {
+                    "From": 0, //No open remote admin port in range 0-10
+                    "To": 10
+                },
+            },
+        ],
+        "IsDefault": true,
+        "NetworkAclId": "acl-65603818",
+        "Tags": [],
+        "VpcId": "vpc-99de2fe4",
+        "OwnerId": "111122223333"
+    },
+    {
+        "Associations": [
+            {
+                "NetworkAclAssociationId": "aclassoc-3ddddf7f",
+                "NetworkAclId": "acl-65603818",
+                "SubnetId": "subnet-06aa0f60"
+            }
+        ],
+        "Entries": [
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": false,
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100,
+                "PortRange": {
+                    "From": 0, // Fail because of SSH
+                    "To": 100
+                },
+            },
+
+        ],
+        "IsDefault": true,
+        "NetworkAclId": "acl-65603818",
+        "Tags": [],
+        "VpcId": "vpc-99de2fe4",
+        "OwnerId": "111122223333"
+    },
+    {
+        "Associations": [
+            {
+                "NetworkAclAssociationId": "aclassoc-3ddddf7f",
+                "NetworkAclId": "acl-65603818",
+                "SubnetId": "subnet-06aa0f60"
+            }
+        ],
+        "Entries": [
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": true, //Pass because egress
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100,
+                "PortRange": {
+                    "From": 0,
+                    "To": 100
+                },
+            },
+
+        ],
+        "IsDefault": true,
+        "NetworkAclId": "acl-65603818",
+        "Tags": [],
+        "VpcId": "vpc-99de2fe4",
+        "OwnerId": "111122223333"
+    }
+];
+
+const createCache = (networkAcls) => {
+    return {
+        ec2: {
+            describeNetworkAcls: {
+                'us-east-1': {
+                    data: networkAcls
+                },
+            },
+        },
+    };
+};
+
+const createErrorCache = () => {
+    return {
+        ec2: {
+            describeNetworkAcls: {
+                'us-east-1': {
+                    err: {
+                        message: 'error describing Network ACLs'
+                    },
+                },
+            },
+        },
+    };
+};
+
+const createNullCache = () => {
+    return {
+        ec2: {
+            describeNetworkAcls: {
+                'us-east-1': null,
+            },
+        },
+    };
+};
+
+
+describe('networkAclInboundTraffic', function () {
+    describe('run', function () {
+        it('should PASS if network ACL does not allow unrestricted access', function (done) {
+            const cache = createCache([describeNetworkAcls[0]]);
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                done();
+            });
+        });
+
+        it('should FAIL if network ACL allows unrestricted access egress is disabled', function (done) {
+            const cache = createCache([describeNetworkAcls[1]]);
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                done();
+            });
+        });
+
+        it('should PASS if network ACL has no ingress rules', function (done) {
+            const cache = createCache([describeNetworkAcls[2]]);
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                done();
+            });
+        });
+
+        it('should PASS if no network ACLs found', function (done) {
+            const cache = createCache([]);
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                done();
+            });
+        });
+
+        it('should UNKNOWN if unable to describe network ACLs', function (done) {
+            const cache = createErrorCache();
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                done();
+            });
+        });
+
+        it('should not return anything if describe network ACLs response is not found', function (done) {
+            const cache = createNullCache();
+
+            networkAclInboundTraffic.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});

--- a/plugins/aws/s3/bucketMFADeleteEnabled.js
+++ b/plugins/aws/s3/bucketMFADeleteEnabled.js
@@ -5,9 +5,9 @@ module.exports = {
     category: 'S3',
     domain: 'Storage',
     description: 'Ensures MFA delete is enabled on S3 buckets',
-    more_info: 'Adding MFA delete adds another layer of security while changing the version state\
-                in the event of security credentials being compromised or unauthorized\
-                access being granted.',
+    more_info: 'Adding MFA delete adds another layer of security while changing the version state' +
+        'in the event of security credentials being compromised or unauthorized' +
+        'access being granted.',
     recommended_action: 'Enable MFA Delete on S3 buckets.',
     link: 'https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html',
     apis: ['S3:listBuckets', 'S3:getBucketVersioning', 'S3:getBucketLocation'],
@@ -15,9 +15,9 @@ module.exports = {
         cis1: '2.1.3 Ensure MFA Delete is enabled on S3 buckets',
     },
     settings: {
-        whitelist_mfa_del_enabled_buckets: {
-            name: 'Whitelist MFA Delete Enabled Buckets',
-            description: 'All buckets against this regex will be whitelisted',
+        whitelist_buckets_for_mfa_deletion: {
+            name: 'Whitelist Buckets For MFA Deletion',
+            description: 'List of comma separated buckets which should be whitelisted to check',
             regex: '^.*$',
             default: '',
         }
@@ -27,20 +27,37 @@ module.exports = {
         var results = [];
         var source = {};
         var region = helpers.defaultRegion(settings);
+        
+        var config = {
+            whitelist_buckets_for_mfa_deletion: settings.whitelist_buckets_for_mfa_deletion || this.settings.whitelist_buckets_for_mfa_deletion.default
+        };
+        
         var listBuckets = helpers.addSource(cache, source,
             ['s3', 'listBuckets', region]);
+
         if (!listBuckets) return callback(null, results, source);
         if (listBuckets.err || !listBuckets.data) {
             helpers.addResult(results, 3,
                 'Unable to query for S3 buckets: ' + helpers.addError(listBuckets));
             return callback(null, results, source);
         }
+
         if (!listBuckets.data.length) {
             helpers.addResult(results, 0, 'No S3 buckets to check');
             return callback(null, results, source);
         }
+
         listBuckets.data.forEach(function(bucket){
+            if (bucket.Name == helpers.CLOUDSPLOIT_EVENTS_BUCKET) return;
+            
             var bucketLocation = helpers.getS3BucketLocation(cache, region, bucket.Name);
+            
+            if (config.whitelist_buckets_for_mfa_deletion.includes(bucket.Name)) {
+                helpers.addResult(results, 2,
+                    'Bucket : ' + bucket.Name + ' is whitelisted',
+                    bucketLocation, 'arn:aws:s3:::' + bucket.Name);
+                return;
+            }
 
             var getBucketVersioning = helpers.addSource(cache, source,
                 ['s3', 'getBucketVersioning', region, bucket.Name]);
@@ -50,7 +67,7 @@ module.exports = {
                     'Error querying bucket versioning for : ' + bucket.Name +
                     ': ' + helpers.addError(getBucketVersioning),
                     bucketLocation, 'arn:aws:s3:::' + bucket.Name);
-            } else if (getBucketVersioning.data.MFADelete === 'Enabled') {
+            } else if (getBucketVersioning.data.MFADelete && getBucketVersioning.data.MFADelete.toUpperCase() === 'ENABLED') {
                 helpers.addResult(results, 0,
                     'Bucket : ' + bucket.Name + ' has MFA Delete enabled',
                     bucketLocation, 'arn:aws:s3:::' + bucket.Name);

--- a/plugins/aws/s3/bucketMFADeleteEnabled.js
+++ b/plugins/aws/s3/bucketMFADeleteEnabled.js
@@ -4,7 +4,7 @@ module.exports = {
     title: 'S3 Bucket MFA Delete Status',
     category: 'S3',
     domain: 'Storage',
-    description: 'Ensures MFA delete is enabled on S3 buckets',
+    description: 'Ensures MFA delete is enabled on S3 buckets.',
     more_info: 'Adding MFA delete adds another layer of security while changing the version state' +
         'in the event of security credentials being compromised or unauthorized' +
         'access being granted.',

--- a/plugins/aws/s3/bucketMFADeleteEnabled.js
+++ b/plugins/aws/s3/bucketMFADeleteEnabled.js
@@ -1,0 +1,65 @@
+var helpers = require('../../../helpers/aws');
+
+module.exports = {
+    title: 'S3 Bucket MFA Delete Status',
+    category: 'S3',
+    domain: 'Storage',
+    description: 'Ensures MFA delete is enabled on S3 buckets',
+    more_info: 'Adding MFA delete adds another layer of security while changing the version state\
+                in the event of security credentials being compromised or unauthorized\
+                access being granted.',
+    recommended_action: 'Enable MFA Delete on S3 buckets.',
+    link: 'https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html',
+    apis: ['S3:listBuckets', 'S3:getBucketVersioning', 'S3:getBucketLocation'],
+    compliance: {
+        cis1: '2.1.3 Ensure MFA Delete is enabled on S3 buckets',
+    },
+    settings: {
+        whitelist_mfa_del_enabled_buckets: {
+            name: 'Whitelist MFA Delete Enabled Buckets',
+            description: 'All buckets against this regex will be whitelisted',
+            regex: '^.*$',
+            default: '',
+        }
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var region = helpers.defaultRegion(settings);
+        var listBuckets = helpers.addSource(cache, source,
+            ['s3', 'listBuckets', region]);
+        if (!listBuckets) return callback(null, results, source);
+        if (listBuckets.err || !listBuckets.data) {
+            helpers.addResult(results, 3,
+                'Unable to query for S3 buckets: ' + helpers.addError(listBuckets));
+            return callback(null, results, source);
+        }
+        if (!listBuckets.data.length) {
+            helpers.addResult(results, 0, 'No S3 buckets to check');
+            return callback(null, results, source);
+        }
+        listBuckets.data.forEach(function(bucket){
+            var bucketLocation = helpers.getS3BucketLocation(cache, region, bucket.Name);
+
+            var getBucketVersioning = helpers.addSource(cache, source,
+                ['s3', 'getBucketVersioning', region, bucket.Name]);
+
+            if (!getBucketVersioning || getBucketVersioning.err || !getBucketVersioning.data) {
+                helpers.addResult(results, 3,
+                    'Error querying bucket versioning for : ' + bucket.Name +
+                    ': ' + helpers.addError(getBucketVersioning),
+                    bucketLocation, 'arn:aws:s3:::' + bucket.Name);
+            } else if (getBucketVersioning.data.MFADelete === 'Enabled') {
+                helpers.addResult(results, 0,
+                    'Bucket : ' + bucket.Name + ' has MFA Delete enabled',
+                    bucketLocation, 'arn:aws:s3:::' + bucket.Name);
+            } else {
+                helpers.addResult(results, 2,
+                    'Bucket : ' + bucket.Name + ' has MFA Delete disabled',
+                    bucketLocation, 'arn:aws:s3:::' + bucket.Name);
+            }
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/aws/s3/bucketMFADeleteEnabled.spec.js
+++ b/plugins/aws/s3/bucketMFADeleteEnabled.spec.js
@@ -1,0 +1,171 @@
+var expect = require('chai').expect;
+const bucketMFAStatus = require('./bucketMFADeleteEnabled');
+
+const listBuckets = [
+    {
+        Name: 'elasticbeanstalk-us-east-1-111122223333',
+        CreationDate: '2020-08-20T17:42:52.000Z'
+    },
+    {
+        Name: 'test-bucket-130',
+        CreationDate: '2020-09-10T09:11:40.000Z'
+    },
+    {
+        Name: 'test-bucket-sploit-100',
+        CreationDate: '2020-09-06T09:44:16.000Z'
+    }
+];
+
+const getBucketVersioning = [
+    {
+        Status: 'Enabled',
+        MFADelete: 'Enabled'
+    },
+    {
+        Status: 'Enabled',
+        MFADelete: 'Disabled'
+    },
+    {}
+];
+
+const createCache = (buckets, versioning) => {
+    var bucketName = (buckets && buckets.length) ? buckets[0].Name : null;
+    return {
+        s3: {
+            listBuckets: {
+                'us-east-1': {
+                    data: buckets
+                },
+            },
+            getBucketVersioning: {
+                'us-east-1': {
+                    [bucketName]: {
+                        data: versioning
+                    },
+                },
+            },
+            getBucketLocation: {
+                'us-east-1': {
+                    [bucketName]: {
+                        data: {
+                            LocationConstraint: 'us-east-1'
+                        }
+                    }
+                }
+            }
+        },
+    };
+};
+
+const createErrorCache = () => {
+    return {
+        s3: {
+            listBuckets: {
+                'us-east-1': {
+                    err: {
+                        message: 'error while listing s3 buckets'
+                    },
+                },
+            },
+            getBucketVersioning: {
+                'us-east-1': {
+                    err: {
+                        message: 'error while getting bucket versioning'
+                    },
+                },
+            },
+        },
+    };
+};
+
+const createBucketVersioningErrorCache = (buckets) => {
+    return {
+        s3: {
+            listBuckets: {
+                'us-east-1': {
+                    data: buckets
+                },
+            },
+            getBucketVersioning: {
+                'us-east-1': {
+                    err: {
+                        message: 'error while getting bucket versioning'
+                    },
+                },
+            },
+        },
+    };
+};
+
+const createNullCache = () => {
+    return {
+        s3: {
+            listBuckets: {
+                'us-east-1': null,
+            },
+            getBucketVersioning: {
+                'us-east-1': null,
+            },
+        },
+    };
+};
+
+describe('bucketMFAStatus', function () {
+    describe('run', function () {
+        it('should PASS if S3 bucket has MFA Delete enabled', function (done) {
+            const cache = createCache([listBuckets[0]], getBucketVersioning[0]);
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].region).to.equal('us-east-1');
+                done();
+            });
+        });
+
+        it('should FAIL if S3 bucket has MFA Delete disabled', function (done) {
+            const cache = createCache([listBuckets[0]], getBucketVersioning[1]);
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].region).to.equal('us-east-1');
+                done();
+            });
+        });
+
+        it('should PASS if no S3 bucket found', function (done) {
+            const cache = createCache([]);
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                done();
+            });
+        });
+
+        it('should UNKNOWN if unable to list s3 buckets', function (done) {
+            const cache = createErrorCache();
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                done();
+            });
+        });
+
+        it('should UNKNOWN if unable to get bucket MFA Delete', function (done) {
+            const cache = createBucketVersioningErrorCache([listBuckets[0]]);
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                done();
+            });
+        });
+
+        it('should not return any result if s3 list buckets response is not found', function (done) {
+            const cache = createNullCache();
+            bucketMFAStatus.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(0);
+                done();
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
In this change we have added/modified AWS plugins as per CIS 1.5.0 benchamrks. We have added plugins  for 

- S3-BucketMFADelete Enabled and 
- EC2- NetworkACL Inboud Egress Rules. 
- We have expanded the audits for CloudWatch/MonitoringMetrics to include the Organizations Changes filter also.