### PR TITLE
Fix XML formatting

### DIFF
--- a/postprocess/output.js
+++ b/postprocess/output.js
@@ -13,6 +13,16 @@ function commaSafe(str) {
     return str.replace(/,/g, ' ');
 }
 
+function XMLSafe(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
 function log(msg, settings) {
     if (!settings.mocha) console.log(msg);
 }
@@ -177,7 +187,7 @@ module.exports = {
                     time = time.substr(0, time.indexOf('.'));
 
                     this.testSuites[suiteName] = {
-                        name: plugin.title + ': ' + (plugin.description || ''),
+                        name: XMLSafe(plugin.title + ': ' + (plugin.description || '')),
                         package: pluginKey,
                         failures: 0,
                         errors: 0,
@@ -202,12 +212,12 @@ module.exports = {
                 var name = result.region + '; ' + (result.resource || 'N/A') + '; ' + result.message;
 
                 testSuite.testCases.push({
-                    name: name,
+                    name: XMLSafe(name),
                     classname: pluginKey,
                     file: '',
                     line: 0,
-                    failure: failure,
-                    error: error
+                    failure: XMLSafe(failure),
+                    error: XMLSafe(error)
                 });
             },
         

--- a/postprocess/output.spec.js
+++ b/postprocess/output.spec.js
@@ -65,6 +65,19 @@ describe('output', function () {
             expect(buffer.cache).to.include(' errors="1" ');
             expect(buffer.cache).to.include('error message');
         })
+
+        it('content should not contain XML characters', function() {
+            var buffer = createOutputBuffer();
+            var handler = output.createJunit(buffer, { mocha: true, junit: 'test.junit' });
+            handler.writeResult({status: 0}, {title:'myTitle&<>"\''}, 'key');
+            handler.writeResult({status: 2, message: 'fail message&<>"\''}, {title:'myTitleFail'}, 'key-fail');
+            handler.writeResult({status: 3, message: 'error message&<>"\''}, {title:'myTitleError'}, 'key-error');
+            handler.close();
+
+            expect(buffer.cache).to.include('myTitle&amp;&lt;&gt;&quot;&apos;');
+            expect(buffer.cache).to.include(' fail message&amp;&lt;&gt;&quot;&apos;');
+            expect(buffer.cache).to.include(' error message&amp;&lt;&gt;&quot;&apos;');
+        })
     })
 
     describe('csv', function () {


### PR DESCRIPTION
jUnit output mode leaves XML characters (&<>”’) in the title and messages, leading to invalid XML being generated.

This patch adds a function to replace those characters with corresponding XML entities.

Fixes #1128 

Signed-off-by: Gabriel Boucher <gboucher@curelator.com>