### PR TITLE
fix: add return on data requirement check in mysqlFlexibleServersMinTls

### DIFF
--- a/plugins/azure/mysqlserver/mysqlFlexibleServersMinTls.js
+++ b/plugins/azure/mysqlserver/mysqlFlexibleServersMinTls.js
@@ -40,6 +40,7 @@ module.exports = {
                 if (!configurations || configurations.err || !configurations.data) {
                     helpers.addResult(results, 3,
                         'Unable to query for  ' + helpers.addError(configurations), location, flexibleServer.id);
+                     return rcb();
                 }
                     
                 var configuration = configurations.data.filter(config => {


### PR DESCRIPTION
Prevent code from running when required data not present for the plugin mysqlserver azure. It fixes the following error:

```
/app/cloudsploit/plugins/azure/mysqlserver/mysqlFlexibleServersMinTls.js:45
                var configuration = configurations.data.filter(config => {
                                                        ^

TypeError: Cannot read properties of undefined (reading 'filter')
    at /app/cloudsploit/plugins/azure/mysqlserver/mysqlFlexibleServersMinTls.js:45:57
    at /app/cloudsploit/node_modules/async/dist/async.js:3113:16
    at eachOfArrayLike (/app/cloudsploit/node_modules/async/dist/async.js:1072:9)
    at eachOf (/app/cloudsploit/node_modules/async/dist/async.js:1120:5)
    at Object.eachLimit (/app/cloudsploit/node_modules/async/dist/async.js:3175:5)
    at Object.run (/app/cloudsploit/plugins/azure/mysqlserver/mysqlFlexibleServersMinTls.js:19:15)
    at /app/cloudsploit/engine.js:223:28
    at /app/cloudsploit/node_modules/async/dist/async.js:3685:9
    at replenish (/app/cloudsploit/node_modules/async/dist/async.js:1014:17)
    at iterateeCallback (/app/cloudsploit/node_modules/async/dist/async.js:998:17)
```