### PR TITLE
Fix IAM policy parsing for "*" resources

### DIFF
--- a/plugins/aws/iam/rolePolicyUnusedServices.js
+++ b/plugins/aws/iam/rolePolicyUnusedServices.js
@@ -410,7 +410,9 @@ module.exports = {
                                         statement.Action[0].split(':')[1].toLowerCase();
                                     if (statement.Action.length > 1 || statement.Action[0] !== '*') {
                                         for (let action of statement.Action) {
-                                            if (config.whitelist_unused_actions_for_resources.includes(action)) continue;
+                                            if (config.whitelist_unused_actions_for_resources.includes(action) || 
+                                                (action.length && action[0] === '*')) 
+                                                continue;
                                             let resourceAction = action.split(':')[1].toLowerCase();
 
                                             if (allServices[service] && !config.whitelist_unused_services.includes(service)) {


### PR DESCRIPTION
This PR addresses the following issue in policy parsing:

1. In case a resource policy is for "*" resources, the given iam policy parsing will fail as `action.split[":"][1]` will be `null`. 