### PR TITLE
Adding output handler for SARIF JSON format

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ parser.add_argument('--china', {
 parser.add_argument('--csv', { help: 'Output: CSV file' });
 parser.add_argument('--json', { help: 'Output: JSON file' });
 parser.add_argument('--junit', { help: 'Output: Junit file' });
+parser.add_argument('--sarif', { help: 'Output: SARIF JSON file' });
 parser.add_argument('--console', {
     help: 'Console output format. Default: table',
     choices: ['none', 'text', 'table'],


### PR DESCRIPTION
This PR will allow to generate the output using SARIF JSON format when using the following command

```bash
node index.js --cloud aws --config ./config.js --sarif=output.sarif.json --console=none --plugin s3Encryption
```

Basically it just adding a new parameter **"sarif=filename"**

The output handle will generate the following format:
```json
{
  "version": "2.1.0",
  "$schema": "http://json.schemastore.org/sarif-2.1.0",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "cloudsploit",
          "version": "3.1.0",
          "informationUri": "https://github.com/aquasecurity/cloudsploit"
        }
      },
      "results": [
        {
          "level": "error",
          "message": {
            "text": "No bucket policy found; encryption not enforced"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "arn:aws:s3:::sfqdwr"
                }
              }
            }
          ],
          "ruleId": "S3-S3ENCRYPTION"
        }
      ]
    }
  ]
}
```

> This is a valid SARIF file, check [here](https://sarifweb.azurewebsites.net/Validation)

Fix #1726 