### PR TITLE
Migrate AWS SDK for JavaScript from v2 to v3

### DIFF
--- a/collectors/aws/accessanalyzer/listFindings.js
+++ b/collectors/aws/accessanalyzer/listFindings.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    AccessAnalyzer
+} = require("@aws-sdk/client-accessanalyzer");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var accessanalyzer = new AWS.AccessAnalyzer(AWSConfig);
+    var accessanalyzer = new AccessAnalyzer(AWSConfig);
     async.eachLimit(collection.accessanalyzer.listAnalyzers[AWSConfig.region].data, 15, function(analyzer, cb) {
         collection.accessanalyzer.listFindings[AWSConfig.region][analyzer.arn] = {};
         var params = {

--- a/collectors/aws/apigateway/getClientCertificate.js
+++ b/collectors/aws/apigateway/getClientCertificate.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    APIGateway
+} = require("@aws-sdk/client-api-gateway");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var apigateway = new AWS.APIGateway(AWSConfig);
+    var apigateway = new APIGateway(AWSConfig);
 
     async.eachLimit(collection.apigateway.getRestApis[AWSConfig.region].data, 5, function(api, cb){
         if (!collection.apigateway.getStages ||

--- a/collectors/aws/apigateway/getIntegration.js
+++ b/collectors/aws/apigateway/getIntegration.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    APIGateway
+} = require("@aws-sdk/client-api-gateway");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var apigateway = new AWS.APIGateway(AWSConfig);
+    var apigateway = new APIGateway(AWSConfig);
 
     async.eachLimit(collection.apigateway.getRestApis[AWSConfig.region].data, 5, function(api, cb){
         if (!collection.apigateway.getResources ||

--- a/collectors/aws/appmesh/describeVirtualGateway.js
+++ b/collectors/aws/appmesh/describeVirtualGateway.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    AppMesh
+} = require("@aws-sdk/client-app-mesh");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var appmesh = new AWS.AppMesh(AWSConfig);
+    var appmesh = new AppMesh(AWSConfig);
 
     if (!collection.appmesh ||
         !collection.appmesh.listMeshes ||

--- a/collectors/aws/autoscaling/describeLaunchConfigurations.js
+++ b/collectors/aws/autoscaling/describeLaunchConfigurations.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    AutoScaling
+} = require("@aws-sdk/client-auto-scaling");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var autoscaling = new AWS.AutoScaling(AWSConfig);
+    var autoscaling = new AutoScaling(AWSConfig);
 
     async.eachLimit(collection.autoscaling.describeAutoScalingGroups[AWSConfig.region].data, 15, function(asg, cb){
         collection.autoscaling.describeLaunchConfigurations[AWSConfig.region][asg.AutoScalingGroupARN] = {};

--- a/collectors/aws/autoscaling/describeNotificationConfigurations.js
+++ b/collectors/aws/autoscaling/describeNotificationConfigurations.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    AutoScaling
+} = require("@aws-sdk/client-auto-scaling");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var autoscaling = new AWS.AutoScaling(AWSConfig);
+    var autoscaling = new AutoScaling(AWSConfig);
 
     async.eachLimit(collection.autoscaling.describeAutoScalingGroups[AWSConfig.region].data, 15, function(asg, cb){        
         var params = {

--- a/collectors/aws/cloudfront/getDistribution.js
+++ b/collectors/aws/cloudfront/getDistribution.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudFront
+} = require("@aws-sdk/client-cloudfront");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudfront = new AWS.CloudFront(AWSConfig);
+    var cloudfront = new CloudFront(AWSConfig);
 
     async.eachLimit(collection.cloudfront.listDistributions[AWSConfig.region].data, 15, function(distribution, cb){        
         collection.cloudfront.getDistribution[AWSConfig.region][distribution.Id] = {};

--- a/collectors/aws/cloudtrail/listTags.js
+++ b/collectors/aws/cloudtrail/listTags.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudTrail
+} = require("@aws-sdk/client-cloudtrail");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudtrail = new AWS.CloudTrail(AWSConfig);
+    var cloudtrail = new CloudTrail(AWSConfig);
 
     async.eachLimit(collection.cloudtrail.describeTrails[AWSConfig.region].data, 15, function(trail, cb) {
         var params = {

--- a/collectors/aws/cloudwatch/getEc2MetricStatistics.js
+++ b/collectors/aws/cloudwatch/getEc2MetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require('../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
 
     async.eachLimit(collection.ec2.describeInstances[AWSConfig.region].data, 10, function(reservation, cb) {
         reservation.Instances.forEach(instance => {

--- a/collectors/aws/cloudwatch/getEcMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getEcMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.elasticache.describeCacheClusters[AWSConfig.region].data, 10, function(cluster, cb){        
         collection.cloudwatch.getEcMetricStatistics[AWSConfig.region][cluster.CacheClusterId] = {};

--- a/collectors/aws/cloudwatch/getEsMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getEsMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.opensearch.listDomainNames[AWSConfig.region].data, 10, function(domain, cb){        
         collection.cloudwatch.getEsMetricStatistics[AWSConfig.region][domain.DomainName] = {};

--- a/collectors/aws/cloudwatch/getRdsMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getRdsMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.rds.describeDBInstances[AWSConfig.region].data, 10, function(instance, cb){        
         collection.cloudwatch.getRdsMetricStatistics[AWSConfig.region][instance.DBInstanceIdentifier] = {};

--- a/collectors/aws/cloudwatch/getRdsReadIOPSMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getRdsReadIOPSMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.rds.describeDBInstances[AWSConfig.region].data, 10, function(instance, cb){        
         collection.cloudwatch.getRdsReadIOPSMetricStatistics[AWSConfig.region][instance.DBInstanceIdentifier] = {};

--- a/collectors/aws/cloudwatch/getRdsWriteIOPSMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getRdsWriteIOPSMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.rds.describeDBInstances[AWSConfig.region].data, 10, function(instance, cb){        
         collection.cloudwatch.getRdsWriteIOPSMetricStatistics[AWSConfig.region][instance.DBInstanceIdentifier] = {};

--- a/collectors/aws/cloudwatch/getredshiftMetricStatistics.js
+++ b/collectors/aws/cloudwatch/getredshiftMetricStatistics.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CloudWatch
+} = require("@aws-sdk/client-cloudwatch");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var cloudwatch = new AWS.CloudWatch(AWSConfig);
+    var cloudwatch = new CloudWatch(AWSConfig);
    
     async.eachLimit(collection.redshift.describeClusters[AWSConfig.region].data, 10, function(cluster, cb){        
         collection.cloudwatch.getredshiftMetricStatistics[AWSConfig.region][cluster.ClusterIdentifier] = {};

--- a/collectors/aws/codebuild/batchGetProjects.js
+++ b/collectors/aws/codebuild/batchGetProjects.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    CodeBuild
+} = require("@aws-sdk/client-codebuild");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var codebuild = new AWS.CodeBuild(AWSConfig);
+    var codebuild = new CodeBuild(AWSConfig);
 
     async.eachLimit(collection.codebuild.listProjects[AWSConfig.region].data, 15, function(project, cb){
         collection.codebuild.batchGetProjects[AWSConfig.region][project] = {};

--- a/collectors/aws/collector.js
+++ b/collectors/aws/collector.js
@@ -17,6 +17,11 @@
  *********************/
 
 var AWS = require('aws-sdk');
+
+const {
+    EC2
+} = require("@aws-sdk/client-ec2");
+
 var async = require('async');
 var https = require('https');
 var helpers = require(__dirname + '/../../helpers/aws');
@@ -24,6 +29,9 @@ var collectors = require(__dirname + '/../../collectors/aws');
 var collectData = require(__dirname + '/../../helpers/shared.js');
 // Override max sockets
 var agent = new https.Agent({maxSockets: 100});
+// JS SDK v3 does not support global configuration.
+// Codemod has attempted to pass values to each service client in this file.
+// You may need to update clients outside of this file, if they use global config.
 AWS.config.update({httpOptions: {agent: agent}});
 
 var rateError = {message: 'rate', statusCode: 429};
@@ -63,7 +71,7 @@ var collect = function(AWSConfig, settings, callback) {
 
     let runApiCalls = [];
 
-    var AWSEC2 = new AWS.EC2(AWSConfig);
+    var AWSEC2 = new EC2(AWSConfig);
     var params = {AllRegions: true};
     var excludeRegions = [];
 

--- a/collectors/aws/collector_multipart.js
+++ b/collectors/aws/collector_multipart.js
@@ -17,6 +17,11 @@
  *********************/
 
 var AWS = require('aws-sdk');
+
+const {
+    EC2
+} = require("@aws-sdk/client-ec2");
+
 var async = require('async');
 var https = require('https');
 var helpers = require(__dirname + '/../../helpers/aws');
@@ -25,6 +30,9 @@ var collectData = require(__dirname + '/../../helpers/shared.js');
 
 // Override max sockets
 var agent = new https.Agent({maxSockets: 100});
+// JS SDK v3 does not support global configuration.
+// Codemod has attempted to pass values to each service client in this file.
+// You may need to update clients outside of this file, if they use global config.
 AWS.config.update({httpOptions: {agent: agent}});
 
 var CALLS_CONFIG = {
@@ -80,7 +88,7 @@ var collect = function(AWSConfig, settings, callback) {
 
     let runApiCalls = [];
 
-    var AWSEC2 = new AWS.EC2(AWSConfig);
+    var AWSEC2 = new EC2(AWSConfig);
     var params = {AllRegions: true};
     var excludeRegions = [];
     var timeoutCheck;

--- a/collectors/aws/connect/instanceAttachmentStorageConfigs.js
+++ b/collectors/aws/connect/instanceAttachmentStorageConfigs.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Connect
+} = require("@aws-sdk/client-connect");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var connect = new AWS.Connect(AWSConfig);
+    var connect = new Connect(AWSConfig);
 
     async.eachLimit(collection.connect.listInstances[AWSConfig.region].data, 15, function(instance, cb){
         collection.connect.instanceAttachmentStorageConfigs[AWSConfig.region][instance.Id] = {};

--- a/collectors/aws/connect/listInstanceCallRecordingStorageConfigs.js
+++ b/collectors/aws/connect/listInstanceCallRecordingStorageConfigs.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Connect
+} = require("@aws-sdk/client-connect");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var connect = new AWS.Connect(AWSConfig);
+    var connect = new Connect(AWSConfig);
 
     async.eachLimit(collection.connect.listInstances[AWSConfig.region].data, 15, function(instance, cb){
         collection.connect.listInstanceCallRecordingStorageConfigs[AWSConfig.region][instance.Id] = {};

--- a/collectors/aws/connect/listInstanceChatTranscriptStorageConfigs.js
+++ b/collectors/aws/connect/listInstanceChatTranscriptStorageConfigs.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Connect
+} = require("@aws-sdk/client-connect");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var connect = new AWS.Connect(AWSConfig);
+    var connect = new Connect(AWSConfig);
 
     async.eachLimit(collection.connect.listInstances[AWSConfig.region].data, 15, function(instance, cb){
         collection.connect.listInstanceChatTranscriptStorageConfigs[AWSConfig.region][instance.Id] = {};

--- a/collectors/aws/connect/listInstanceExportedReportStorageConfigs.js
+++ b/collectors/aws/connect/listInstanceExportedReportStorageConfigs.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Connect
+} = require("@aws-sdk/client-connect");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var connect = new AWS.Connect(AWSConfig);
+    var connect = new Connect(AWSConfig);
 
     async.eachLimit(collection.connect.listInstances[AWSConfig.region].data, 15, function(instance, cb){
         collection.connect.listInstanceExportedReportStorageConfigs[AWSConfig.region][instance.Id] = {};

--- a/collectors/aws/connect/listInstanceMediaStreamStorageConfigs.js
+++ b/collectors/aws/connect/listInstanceMediaStreamStorageConfigs.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Connect
+} = require("@aws-sdk/client-connect");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var connect = new AWS.Connect(AWSConfig);
+    var connect = new Connect(AWSConfig);
 
     async.eachLimit(collection.connect.listInstances[AWSConfig.region].data, 15, function(instance, cb){
         collection.connect.listInstanceMediaStreamStorageConfigs[AWSConfig.region][instance.Id] = {};

--- a/collectors/aws/dynamodb/describeContinuousBackups.js
+++ b/collectors/aws/dynamodb/describeContinuousBackups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    DynamoDB
+} = require("@aws-sdk/client-dynamodb");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var dynamodb = new AWS.DynamoDB(AWSConfig);
+    var dynamodb = new DynamoDB(AWSConfig);
 
     async.eachLimit(collection.dynamodb.listTables[AWSConfig.region].data, 15, function(table, cb){
         collection.dynamodb.describeContinuousBackups[AWSConfig.region][table] = {};

--- a/collectors/aws/dynamodb/describeTable.js
+++ b/collectors/aws/dynamodb/describeTable.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    DynamoDB
+} = require("@aws-sdk/client-dynamodb");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var dynamodb = new AWS.DynamoDB(AWSConfig);
+    var dynamodb = new DynamoDB(AWSConfig);
 
     async.eachLimit(collection.dynamodb.listTables[AWSConfig.region].data, 15, function(table, cb){
         collection.dynamodb.describeTable[AWSConfig.region][table] = {};

--- a/collectors/aws/dynamodb/listBackups.js
+++ b/collectors/aws/dynamodb/listBackups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    DynamoDB
+} = require("@aws-sdk/client-dynamodb");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var dynamodb = new AWS.DynamoDB(AWSConfig);
+    var dynamodb = new DynamoDB(AWSConfig);
 
     async.eachLimit(collection.dynamodb.listTables[AWSConfig.region].data, 15, function(table, cb){
         collection.dynamodb.listBackups[AWSConfig.region][table] = {};

--- a/collectors/aws/ec2/describeSnapshotAttribute.js
+++ b/collectors/aws/ec2/describeSnapshotAttribute.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EC2
+} = require("@aws-sdk/client-ec2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ec2 = new AWS.EC2(AWSConfig);
+    var ec2 = new EC2(AWSConfig);
 
     async.eachLimit(collection.ec2.describeSnapshots[AWSConfig.region].data, 20, function(snapshot, cb){
         collection.ec2.describeSnapshotAttribute[AWSConfig.region][snapshot.SnapshotId] = {};

--- a/collectors/aws/ec2/describeSnapshots.js
+++ b/collectors/aws/ec2/describeSnapshots.js
@@ -1,4 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EC2
+} = require("@aws-sdk/client-ec2");
+
+const {
+    STS
+} = require("@aws-sdk/client-sts");
+
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 // This call must be overridden because the
@@ -6,8 +13,8 @@ var helpers = require(__dirname + '/../../../helpers/aws');
 // available, including public ones
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ec2 = new AWS.EC2(AWSConfig);
-    var sts = new AWS.STS(AWSConfig);
+    var ec2 = new EC2(AWSConfig);
+    var sts = new STS(AWSConfig);
 
     helpers.makeCustomCollectorCall(sts, 'getCallerIdentity', {}, retries, null, null, null, function(stsErr, stsData) {
         if (stsErr || !stsData.Account) {

--- a/collectors/aws/ec2/describeSubnets.js
+++ b/collectors/aws/ec2/describeSubnets.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EC2
+} = require("@aws-sdk/client-ec2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ec2 = new AWS.EC2(AWSConfig);
+    var ec2 = new EC2(AWSConfig);
 
     async.eachLimit(collection.ec2.describeVpcs[AWSConfig.region].data, 15, function(vpc, cb){
         collection.ec2.describeSubnets[AWSConfig.region][vpc.VpcId] = {};

--- a/collectors/aws/ecs/describeCluster.js
+++ b/collectors/aws/ecs/describeCluster.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachLimit(collection.ecs.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.ecs.describeCluster[AWSConfig.region][cluster] = {};

--- a/collectors/aws/ecs/describeContainerInstances.js
+++ b/collectors/aws/ecs/describeContainerInstances.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachOfLimit(collection.ecs.listContainerInstances[AWSConfig.region], 10, function(containerInstanceData,instance, cb){
         async.eachLimit(containerInstanceData.data, 5, function(containerInstance, ccb){

--- a/collectors/aws/ecs/describeServices.js
+++ b/collectors/aws/ecs/describeServices.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachOfLimit(collection.ecs.listServices[AWSConfig.region], 10, function(servicesData,instance, cb){
         async.eachLimit(servicesData.data, 5, function(service, ccb){

--- a/collectors/aws/ecs/describeTasks.js
+++ b/collectors/aws/ecs/describeTasks.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachOfLimit(collection.ecs.listTasks[AWSConfig.region], 10, function(tasksData,instance, cb){
         async.eachLimit(tasksData.data, 5, function(task, ccb){

--- a/collectors/aws/ecs/listContainerInstances.js
+++ b/collectors/aws/ecs/listContainerInstances.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachLimit(collection.ecs.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.ecs.listContainerInstances[AWSConfig.region][cluster] = {};

--- a/collectors/aws/ecs/listServices.js
+++ b/collectors/aws/ecs/listServices.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachLimit(collection.ecs.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.ecs.listServices[AWSConfig.region][cluster] = {};

--- a/collectors/aws/ecs/listTasks.js
+++ b/collectors/aws/ecs/listTasks.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ECS
+} = require("@aws-sdk/client-ecs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.ECS(AWSConfig);
+    var ecs = new ECS(AWSConfig);
 
     async.eachLimit(collection.ecs.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.ecs.listTasks[AWSConfig.region][cluster] = {};

--- a/collectors/aws/eks/describeCluster.js
+++ b/collectors/aws/eks/describeCluster.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EKS
+} = require("@aws-sdk/client-eks");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var eks = new AWS.EKS(AWSConfig);
+    var eks = new EKS(AWSConfig);
 
     async.eachLimit(collection.eks.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.eks.describeCluster[AWSConfig.region][cluster] = {};

--- a/collectors/aws/eks/describeNodegroups.js
+++ b/collectors/aws/eks/describeNodegroups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EKS
+} = require("@aws-sdk/client-eks");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var eks = new AWS.EKS(AWSConfig);
+    var eks = new EKS(AWSConfig);
     //var autoscaling = new AWS.AutoScaling(AWSConfig);
 
     async.eachLimit(collection.eks.listClusters[AWSConfig.region].data, 5, function(cluster, cb){

--- a/collectors/aws/eks/listNodegroups.js
+++ b/collectors/aws/eks/listNodegroups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EKS
+} = require("@aws-sdk/client-eks");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var eks = new AWS.EKS(AWSConfig);
+    var eks = new EKS(AWSConfig);
 
     async.eachLimit(collection.eks.listClusters[AWSConfig.region].data, 10, function(cluster, cb){
         collection.eks.listNodegroups[AWSConfig.region][cluster] = {};

--- a/collectors/aws/elasticache/describeCacheSubnetGroups.js
+++ b/collectors/aws/elasticache/describeCacheSubnetGroups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElastiCache
+} = require("@aws-sdk/client-elasticache");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elasticache = new AWS.ElastiCache(AWSConfig);
+    var elasticache = new ElastiCache(AWSConfig);
 
     async.eachLimit(collection.elasticache.describeCacheClusters[AWSConfig.region].data, 15, function(cluster, cb){
         collection.elasticache.describeCacheSubnetGroups[AWSConfig.region][cluster.CacheSubnetGroupName] = {};

--- a/collectors/aws/elasticbeanstalk/describeConfigurationSettings.js
+++ b/collectors/aws/elasticbeanstalk/describeConfigurationSettings.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticBeanstalk
+} = require("@aws-sdk/client-elastic-beanstalk");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elasticbeanstalk = new AWS.ElasticBeanstalk(AWSConfig);
+    var elasticbeanstalk = new ElasticBeanstalk(AWSConfig);
 
     async.eachLimit(collection.elasticbeanstalk.describeEnvironments[AWSConfig.region].data, 15, function(environment, cb) {
         var params = {

--- a/collectors/aws/elb/describeInstanceHealth.js
+++ b/collectors/aws/elb/describeInstanceHealth.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancing
+} = require("@aws-sdk/client-elastic-load-balancing");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELB(AWSConfig);
+    var elb = new ElasticLoadBalancing(AWSConfig);
 
     async.eachLimit(collection.elb.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elb.describeInstanceHealth[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/elb/describeLoadBalancerAttributes.js
+++ b/collectors/aws/elb/describeLoadBalancerAttributes.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancing
+} = require("@aws-sdk/client-elastic-load-balancing");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELB(AWSConfig);
+    var elb = new ElasticLoadBalancing(AWSConfig);
 
     async.eachLimit(collection.elb.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elb.describeLoadBalancerAttributes[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/elb/describeLoadBalancerPolicies.js
+++ b/collectors/aws/elb/describeLoadBalancerPolicies.js
@@ -1,11 +1,16 @@
 // TODO: re-visit this one
 
-var AWS = require('aws-sdk');
+
+
+const {
+    ElasticLoadBalancing
+} = require("@aws-sdk/client-elastic-load-balancing");
+
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELB(AWSConfig);
+    var elb = new ElasticLoadBalancing(AWSConfig);
 
     // Gather list of policies from load balancers
     var policies = [];

--- a/collectors/aws/elb/describeTags.js
+++ b/collectors/aws/elb/describeTags.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancing
+} = require("@aws-sdk/client-elastic-load-balancing");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELB(AWSConfig);
+    var elb = new ElasticLoadBalancing(AWSConfig);
 
     async.eachLimit(collection.elb.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elb.describeTags[AWSConfig.region][lb.LoadBalancerName] = {};

--- a/collectors/aws/elbv2/describeListeners.js
+++ b/collectors/aws/elbv2/describeListeners.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancingV2
+} = require("@aws-sdk/client-elastic-load-balancing-v2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELBv2(AWSConfig);
+    var elb = new ElasticLoadBalancingV2(AWSConfig);
 
     async.eachLimit(collection.elbv2.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elbv2.describeListeners[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/elbv2/describeLoadBalancerAttributes.js
+++ b/collectors/aws/elbv2/describeLoadBalancerAttributes.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancingV2
+} = require("@aws-sdk/client-elastic-load-balancing-v2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELBv2(AWSConfig);
+    var elb = new ElasticLoadBalancingV2(AWSConfig);
 
     async.eachLimit(collection.elbv2.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elbv2.describeLoadBalancerAttributes[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/elbv2/describeTags.js
+++ b/collectors/aws/elbv2/describeTags.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancingV2
+} = require("@aws-sdk/client-elastic-load-balancing-v2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELBv2(AWSConfig);
+    var elb = new ElasticLoadBalancingV2(AWSConfig);
 
     async.eachLimit(collection.elbv2.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elbv2.describeTags[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/elbv2/describeTargetGroups.js
+++ b/collectors/aws/elbv2/describeTargetGroups.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ElasticLoadBalancingV2
+} = require("@aws-sdk/client-elastic-load-balancing-v2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var elb = new AWS.ELBv2(AWSConfig);
+    var elb = new ElasticLoadBalancingV2(AWSConfig);
 
     async.eachLimit(collection.elbv2.describeLoadBalancers[AWSConfig.region].data, 15, function(lb, cb){
         collection.elbv2.describeTargetGroups[AWSConfig.region][lb.DNSName] = {};

--- a/collectors/aws/emr/describeSecurityConfiguration.js
+++ b/collectors/aws/emr/describeSecurityConfiguration.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    EMR
+} = require("@aws-sdk/client-emr");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var emr = new AWS.EMR(AWSConfig);
+    var emr = new EMR(AWSConfig);
 
     async.eachLimit(collection.emr.listClusters[AWSConfig.region].data, 15, function(cluster, cb){
         if (!collection.emr.describeCluster ||

--- a/collectors/aws/firehose/describeDeliveryStream.js
+++ b/collectors/aws/firehose/describeDeliveryStream.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Firehose
+} = require("@aws-sdk/client-firehose");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var firehose = new AWS.Firehose(AWSConfig);
+    var firehose = new Firehose(AWSConfig);
 
     async.eachLimit(collection.firehose.listDeliveryStreams[AWSConfig.region].data, 15, function(deliverystream, cb){
         collection.firehose.describeDeliveryStream[AWSConfig.region][deliverystream] = {};

--- a/collectors/aws/guardduty/describePublishingDestination.js
+++ b/collectors/aws/guardduty/describePublishingDestination.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
 
     if (!collection.guardduty ||
         !collection.guardduty.listDetectors ||

--- a/collectors/aws/guardduty/getDetector.js
+++ b/collectors/aws/guardduty/getDetector.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
     async.eachLimit(collection.guardduty.listDetectors[AWSConfig.region].data, 15, function(detectorId, cb) {
         collection.guardduty.getDetector[AWSConfig.region][detectorId] = {};
         var params = {

--- a/collectors/aws/guardduty/getFindings.js
+++ b/collectors/aws/guardduty/getFindings.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
     async.eachLimit(collection.guardduty.listDetectors[AWSConfig.region].data, 15, function(detectorId, dcb) {
         if (!collection.guardduty ||
             !collection.guardduty.listFindings ||

--- a/collectors/aws/guardduty/getMasterAccount.js
+++ b/collectors/aws/guardduty/getMasterAccount.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
     async.eachLimit(collection.guardduty.listDetectors[AWSConfig.region].data, 15, function(detectorId, cb) {
         collection.guardduty.getMasterAccount[AWSConfig.region][detectorId] = {};
         var params = {

--- a/collectors/aws/guardduty/listFindings.js
+++ b/collectors/aws/guardduty/listFindings.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
     async.eachLimit(collection.guardduty.listDetectors[AWSConfig.region].data, 15, function(detectorId, cb) {
         collection.guardduty.listFindings[AWSConfig.region][detectorId] = {};
         var params = {

--- a/collectors/aws/guardduty/listPublishingDestinations.js
+++ b/collectors/aws/guardduty/listPublishingDestinations.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    GuardDuty
+} = require("@aws-sdk/client-guardduty");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var guardduty = new AWS.GuardDuty(AWSConfig);
+    var guardduty = new GuardDuty(AWSConfig);
     async.eachLimit(collection.guardduty.listDetectors[AWSConfig.region].data, 15, function(detectorId, cb) {
         collection.guardduty.listPublishingDestinations[AWSConfig.region][detectorId] = {};
         var params = {

--- a/collectors/aws/iam/generateCredentialReport.js
+++ b/collectors/aws/iam/generateCredentialReport.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     var generateCredentialReport = function(genCb) {
         iam.generateCredentialReport(function(err, data) {

--- a/collectors/aws/iam/getGroupPolicy.js
+++ b/collectors/aws/iam/getGroupPolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     if (!collection.iam ||
         !collection.iam.listGroups ||

--- a/collectors/aws/iam/getInstanceProfile.js
+++ b/collectors/aws/iam/getInstanceProfile.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     if (!collection.ec2 ||
         !collection.ec2.describeInstances ||

--- a/collectors/aws/iam/getPolicyVersion.js
+++ b/collectors/aws/iam/getPolicyVersion.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     if (!collection.iam ||
         !collection.iam.listPolicies ||

--- a/collectors/aws/iam/getRolePolicy.js
+++ b/collectors/aws/iam/getRolePolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     if (!collection.iam ||
         !collection.iam.listRoles ||

--- a/collectors/aws/iam/getUserPolicy.js
+++ b/collectors/aws/iam/getUserPolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
 
     if (!collection.iam ||
         !collection.iam.listUsers ||

--- a/collectors/aws/iam/listRoles.js
+++ b/collectors/aws/iam/listRoles.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    IAM
+} = require("@aws-sdk/client-iam");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var iam = new AWS.IAM(AWSConfig);
+    var iam = new IAM(AWSConfig);
     collection.iam.listRoles[AWSConfig.region] = {};
     var params = {};
 

--- a/collectors/aws/kinesis/describeStream.js
+++ b/collectors/aws/kinesis/describeStream.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Kinesis
+} = require("@aws-sdk/client-kinesis");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var kinesis = new AWS.Kinesis(AWSConfig);
+    var kinesis = new Kinesis(AWSConfig);
 
     async.eachLimit(collection.kinesis.listStreams[AWSConfig.region].data, 15, function(stream, cb){
         collection.kinesis.describeStream[AWSConfig.region][stream] = {};

--- a/collectors/aws/kms/getKeyPolicy.js
+++ b/collectors/aws/kms/getKeyPolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    KMS
+} = require("@aws-sdk/client-kms");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var kms = new AWS.KMS(AWSConfig);
+    var kms = new KMS(AWSConfig);
 
     async.eachLimit(collection.kms.listKeys[AWSConfig.region].data, 15, function(key, cb){
         collection.kms.getKeyPolicy[AWSConfig.region][key.KeyId] = {};

--- a/collectors/aws/kms/listGrants.js
+++ b/collectors/aws/kms/listGrants.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    KMS
+} = require("@aws-sdk/client-kms");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var kms = new AWS.KMS(AWSConfig);
+    var kms = new KMS(AWSConfig);
     async.eachLimit(collection.kms.listKeys[AWSConfig.region].data, 15, function(key, cb) {
         collection.kms.listGrants[AWSConfig.region][key.KeyId] = {};
         var params = {

--- a/collectors/aws/lexmodelsv2/describeBotAlias.js
+++ b/collectors/aws/lexmodelsv2/describeBotAlias.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    LexModelsV2
+} = require("@aws-sdk/client-lex-models-v2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var lexmodelsv2 = new AWS.LexModelsV2(AWSConfig);
+    var lexmodelsv2 = new LexModelsV2(AWSConfig);
 
     if (!collection.lexmodelsv2 ||
         !collection.lexmodelsv2.listBots ||

--- a/collectors/aws/lookoutvision/describeModel.js
+++ b/collectors/aws/lookoutvision/describeModel.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    LookoutVision
+} = require("@aws-sdk/client-lookoutvision");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var lookoutvision = new AWS.LookoutVision(AWSConfig);
+    var lookoutvision = new LookoutVision(AWSConfig);
 
     if (!collection.lookoutvision ||
         !collection.lookoutvision.listProjects ||

--- a/collectors/aws/managedblockchain/getMember.js
+++ b/collectors/aws/managedblockchain/getMember.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    ManagedBlockchain
+} = require("@aws-sdk/client-managedblockchain");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var managedblockchain = new AWS.ManagedBlockchain(AWSConfig);
+    var managedblockchain = new ManagedBlockchain(AWSConfig);
 
     if (!collection.managedblockchain ||
         !collection.managedblockchain.listNetworks ||

--- a/collectors/aws/mwaa/getEnvironment.js
+++ b/collectors/aws/mwaa/getEnvironment.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    MWAA
+} = require("@aws-sdk/client-mwaa");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var mwaa = new AWS.MWAA(AWSConfig);
+    var mwaa = new MWAA(AWSConfig);
 
     async.eachLimit(collection.mwaa.listEnvironments[AWSConfig.region].data, 15, function(env, cb){
         collection.mwaa.getEnvironment[AWSConfig.region][env] = {};

--- a/collectors/aws/opensearchserverless/getEncryptionSecurityPolicy.js
+++ b/collectors/aws/opensearchserverless/getEncryptionSecurityPolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    OpenSearchServerless
+} = require("@aws-sdk/client-opensearchserverless");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.OpenSearchServerless(AWSConfig);
+    var ecs = new OpenSearchServerless(AWSConfig);
 
     async.eachLimit(collection.opensearchserverless.listEncryptionSecurityPolicies[AWSConfig.region].data, 10, function(policy, cb){
         collection.opensearchserverless.getEncryptionSecurityPolicy[AWSConfig.region][policy.name] = {};

--- a/collectors/aws/opensearchserverless/getNetworkSecurityPolicy.js
+++ b/collectors/aws/opensearchserverless/getNetworkSecurityPolicy.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    OpenSearchServerless
+} = require("@aws-sdk/client-opensearchserverless");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ecs = new AWS.OpenSearchServerless(AWSConfig);
+    var ecs = new OpenSearchServerless(AWSConfig);
     async.eachLimit(collection.opensearchserverless.listNetworkSecurityPolicies[AWSConfig.region].data, 10, function(policy, cb){
         collection.opensearchserverless.getNetworkSecurityPolicy[AWSConfig.region][policy.name] = {};
         var params = {

--- a/collectors/aws/opensearchserverless/listEncryptionSecurityPolicies.js
+++ b/collectors/aws/opensearchserverless/listEncryptionSecurityPolicies.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    OpenSearchServerless
+} = require("@aws-sdk/client-opensearchserverless");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var opensearch = new AWS.OpenSearchServerless(AWSConfig);
+    var opensearch = new OpenSearchServerless(AWSConfig);
     collection.opensearchserverless.listEncryptionSecurityPolicies[AWSConfig.region] = {};
     let params = {
         type: 'encryption'

--- a/collectors/aws/opensearchserverless/listNetworkSecurityPolicies.js
+++ b/collectors/aws/opensearchserverless/listNetworkSecurityPolicies.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    OpenSearchServerless
+} = require("@aws-sdk/client-opensearchserverless");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var opensearch = new AWS.OpenSearchServerless(AWSConfig);
+    var opensearch = new OpenSearchServerless(AWSConfig);
     collection.opensearchserverless.listNetworkSecurityPolicies[AWSConfig.region] = {};
     let params = {
         type: 'network'

--- a/collectors/aws/rds/describeDBParameters.js
+++ b/collectors/aws/rds/describeDBParameters.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    RDS
+} = require("@aws-sdk/client-rds");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var rds = new AWS.RDS(AWSConfig);
+    var rds = new RDS(AWSConfig);
     async.eachLimit(collection.rds.describeDBParameterGroups[AWSConfig.region].data, 15, function(group, cb) {
         collection.rds.describeDBParameters[AWSConfig.region][group.DBParameterGroupName] = {};
         var params = {

--- a/collectors/aws/s3/index.js
+++ b/collectors/aws/s3/index.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    S3
+} = require("@aws-sdk/client-s3");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(callKey, forceCloudTrail, AWSConfig, collection, retries, callback) {
-    var s3 = new AWS.S3(AWSConfig);
+    var s3 = new S3(AWSConfig);
 
     var knownBuckets = [];
 
@@ -51,7 +53,7 @@ module.exports = function(callKey, forceCloudTrail, AWSConfig, collection, retri
                         
                         var altAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
                         altAWSConfig.region = locData.LocationConstraint;
-                        var s3Alt = new AWS.S3(altAWSConfig);
+                        var s3Alt = new S3(altAWSConfig);
 
                         s3Alt[callKey]({Bucket:bucket}, function(altErr, altData){
                             if (altErr) {

--- a/collectors/aws/s3control/getPublicAccessBlock.js
+++ b/collectors/aws/s3control/getPublicAccessBlock.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    S3Control
+} = require("@aws-sdk/client-s3-control");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var s3control = new AWS.S3Control(AWSConfig);
+    var s3control = new S3Control(AWSConfig);
 
     var accountId = collection.sts.getCallerIdentity[AWSConfig.region].data;
     collection.s3control.getPublicAccessBlock[AWSConfig.region][accountId] = {};

--- a/collectors/aws/ses/getIdentityDkimAttributes.js
+++ b/collectors/aws/ses/getIdentityDkimAttributes.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    SES
+} = require("@aws-sdk/client-ses");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ses = new AWS.SES(AWSConfig);
+    var ses = new SES(AWSConfig);
     collection.ses.getIdentityDkimAttributes[AWSConfig.region] = {};
 
     var identities = collection.ses.listIdentities[AWSConfig.region].data;

--- a/collectors/aws/sqs/getQueueAttributes.js
+++ b/collectors/aws/sqs/getQueueAttributes.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    SQS
+} = require("@aws-sdk/client-sqs");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var sqs = new AWS.SQS(AWSConfig);
+    var sqs = new SQS(AWSConfig);
 
     async.eachLimit(collection.sqs.listQueues[AWSConfig.region].data, 15, function(queue, cb){
         collection.sqs.getQueueAttributes[AWSConfig.region][queue] = {};

--- a/collectors/aws/ssm/describeParameters.js
+++ b/collectors/aws/ssm/describeParameters.js
@@ -1,8 +1,10 @@
-var AWS = require('aws-sdk');
+const {
+    SSM
+} = require("@aws-sdk/client-ssm");
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var ssm = new AWS.SSM(AWSConfig);
+    var ssm = new SSM(AWSConfig);
     collection.ssm.describeParameters[AWSConfig.region] = {};
     var params = {};
 

--- a/collectors/aws/support/describeTrustedAdvisorCheckResult.js
+++ b/collectors/aws/support/describeTrustedAdvisorCheckResult.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    Support
+} = require("@aws-sdk/client-support");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var support = new AWS.Support(AWSConfig);
+    var support = new Support(AWSConfig);
 
     async.eachLimit(collection.support.describeTrustedAdvisorChecks[AWSConfig.region].data, 15, function(check, cb) {
         collection.support.describeTrustedAdvisorChecks[AWSConfig.region][check] = {};

--- a/collectors/aws/wafregional/listResourcesForWebACL.js
+++ b/collectors/aws/wafregional/listResourcesForWebACL.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    WAFRegional
+} = require("@aws-sdk/client-waf-regional");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var wafregional = new AWS.WAFRegional(AWSConfig);
+    var wafregional = new WAFRegional(AWSConfig);
     async.eachLimit(collection.wafregional.listWebACLs[AWSConfig.region].data, 15, function(dep, depCb){
         async.eachLimit(['APPLICATION_LOAD_BALANCER', 'API_GATEWAY'], 1, function(thisCheck, tcCb){
             if (!collection['wafregional']['listResourcesForWebACL'][AWSConfig.region][dep['WebACLId']]) collection['wafregional']['listResourcesForWebACL'][AWSConfig.region][dep['WebACLId']] = {};

--- a/collectors/aws/wafv2/getWebACL.js
+++ b/collectors/aws/wafv2/getWebACL.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    WAFV2
+} = require("@aws-sdk/client-wafv2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var wafv2 = new AWS.WAFV2(AWSConfig);
+    var wafv2 = new WAFV2(AWSConfig);
 
     async.eachLimit(collection.wafv2.listWebACLs[AWSConfig.region].data, 15, function(acl, cb){        
         var params = {

--- a/collectors/aws/wafv2/getWebACLForCognitoUserPool.js
+++ b/collectors/aws/wafv2/getWebACLForCognitoUserPool.js
@@ -1,10 +1,12 @@
-var AWS = require('aws-sdk');
+const {
+    WAFV2
+} = require("@aws-sdk/client-wafv2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
 
-    var wafv2 = new AWS.WAFV2(AWSConfig);
+    var wafv2 = new WAFV2(AWSConfig);
     var region = 'us-east-1';
     var partition = 'aws';
     if (wafv2.endpoint.hostname.includes('gov')){

--- a/collectors/aws/wafv2/listResourcesForWebACL.js
+++ b/collectors/aws/wafv2/listResourcesForWebACL.js
@@ -1,9 +1,11 @@
-var AWS = require('aws-sdk');
+const {
+    WAFV2
+} = require("@aws-sdk/client-wafv2");
 var async = require('async');
 var helpers = require(__dirname + '/../../../helpers/aws');
 
 module.exports = function(AWSConfig, collection, retries, callback) {
-    var wafv2 = new AWS.WAFV2(AWSConfig);
+    var wafv2 = new WAFV2(AWSConfig);
     async.eachLimit(collection.wafv2.listWebACLs[AWSConfig.region].data, 15, function(dep, depCb){
         async.eachLimit(['APPLICATION_LOAD_BALANCER', 'API_GATEWAY'], 1,  function(thisCheck, tcCb){
             if (!collection['wafv2']['listResourcesForWebACL'][AWSConfig.region][dep['ARN']]) collection['wafv2']['listResourcesForWebACL'][AWSConfig.region][dep['ARN']] = {};


### PR DESCRIPTION
node  is formalizing plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.
We need to migrate code to use AWS SDK for JavaScript (v3).

Migration guide: https://www.npmjs.com/package/aws-sdk-js-codemod
