### PR TITLE
Adding support for gcp user account

### DIFF
--- a/config_example.js
+++ b/config_example.js
@@ -54,7 +54,7 @@ module.exports = {
         },
         google: {
             // OPTION 1: If using a credential JSON file, enter the path below
-            // credential_file: process.env.GOOGLE_APPLICATION_CREDENTIALS || '/path/to/file.json',
+            // credential_file: process.env.GOOGLE_APPLICATION_CREDENTIALS || '/path/to/file.json' || 'path/to/application_default_credentials.json',
             // OPTION 2: If using hard-coded credentials, enter them below
             // project: process.env.GOOGLE_PROJECT_ID || 'my-project',
             // client_email: process.env.GOOGLE_CLIENT_EMAIL || 'cloudsploit@your-project-name.iam.gserviceaccount.com',

--- a/helpers/google/index.js
+++ b/helpers/google/index.js
@@ -2,7 +2,7 @@ var shared        = require(__dirname + '/../shared.js');
 var functions     = require('./functions.js');
 var regRegions    = require('./regions.js');
 
-const {JWT}       = require('google-auth-library');
+const {GoogleAuth}       = require('google-auth-library');
 
 var async         = require('async');
 
@@ -11,12 +11,20 @@ var regions = function() {
 };
 
 var authenticate = async function(GoogleConfig) {
-    const client = new JWT({
-        email: GoogleConfig.client_email,
-        key: GoogleConfig.private_key,
-        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-    });
+    const auth = new GoogleAuth({
+        scopes: 'https://www.googleapis.com/auth/cloud-platform',
+    });   
+  const client = await auth.getClient();
+  try {
+   if (!GoogleConfig.project) {
+ const projectId = await auth.getProjectId();
+  GoogleConfig.project = projectId;
+ }
     return client;
+  } catch (e) {
+    console.error('ERROR: Project ID is not specified. Please ensure you have set the project id using "gcloud config set project YOURPROJECTID"');
+    process.exit(1);
+}
 };
 
 var processCall = function(GoogleConfig, collection, settings, regions, call, service, client, serviceCb) {


### PR DESCRIPTION
Currently, Cloudsploit supports scanning using GCP service accounts.
These changes will add support to run Cloudsploit with GCP user account along with keeping with service account support intact.