### PR TITLE
Enable proxy for aws sdk

### DIFF
--- a/collectors/aws/collector.js
+++ b/collectors/aws/collector.js
@@ -18,12 +18,18 @@
 
 var AWS = require('aws-sdk');
 var async = require('async');
-var https = require('https');
 var helpers = require(__dirname + '/../../helpers/aws');
 var collectors = require(__dirname + '/../../collectors/aws');
 var collectData = require(__dirname + '/../../helpers/shared.js');
+var  proxy = require('proxy-agent');
+
+// Configure proxy from environment variables if exists
+// Envs: http_proxy, https_proxy, no_proxy
+var agent = new proxy.ProxyAgent();
+
 // Override max sockets
-var agent = new https.Agent({maxSockets: 100});
+agent.maxFreeSockets = 100
+
 AWS.config.update({httpOptions: {agent: agent}});
 
 var rateError = {message: 'rate', statusCode: 429};

--- a/collectors/aws/collector_multipart.js
+++ b/collectors/aws/collector_multipart.js
@@ -18,13 +18,18 @@
 
 var AWS = require('aws-sdk');
 var async = require('async');
-var https = require('https');
 var helpers = require(__dirname + '/../../helpers/aws');
 var collectors = require(__dirname + '/../../collectors/aws');
 var collectData = require(__dirname + '/../../helpers/shared.js');
+var  proxy = require('proxy-agent');
+
+// Configure proxy from environment variables if exists
+// Envs: http_proxy, https_proxy, no_proxy
+var agent = new proxy.ProxyAgent();
 
 // Override max sockets
-var agent = new https.Agent({maxSockets: 100});
+agent.maxFreeSockets = 100
+
 AWS.config.update({httpOptions: {agent: agent}});
 
 var CALLS_CONFIG = {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   "dependencies": {
     "@alicloud/pop-core": "^1.7.10",
     "@azure/data-tables": "^13.2.2",
+    "@azure/storage-blob": "^12.14.0",
     "@azure/storage-file-share": "^12.14.0",
     "@azure/storage-queue": "^12.13.0",
-    "@azure/storage-blob": "^12.14.0",
     "@octokit/app": "^3.0.0",
     "@octokit/request": "^3.0.3",
     "@octokit/rest": "^16.3.2",
@@ -57,6 +57,7 @@
     "google-auth-library": "^8.1.1",
     "minimatch": "^3.0.4",
     "ms-rest-azure": "^2.6.0",
+    "proxy-agent": "^6.4.0",
     "tty-table": "^4.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently aws-sdk does not honor the *_proxy convention which leads in consequence to the inability to use cloudsploit behind a proxy.
This change will enable cloudsploit to make use og the *_proxy environment variables to scan through a proxy.
This change applies only to AWS scanning