### PR TITLE
fix: allow to use wildcards in pluginId again

### DIFF
--- a/postprocess/suppress.js
+++ b/postprocess/suppress.js
@@ -15,7 +15,7 @@ module.exports = {
                 throw new Error(`Invalid suppression format: ${expr}. Expected format: pluginId:region:resourceId`);
             }
             
-            const pluginPattern = /^[A-Za-z0-9]{1,255}$/; // eslint-disable-line
+            const pluginPattern = /^[A-Za-z0-9*]{1,255}$/; // eslint-disable-line
             const regionPattern = /^[A-Za-z0-9\-_]{1,255}$/; // eslint-disable-line
             const resourcePattern = /^[ A-Za-z0-9._~()'!*:@,;+?#$%^&={}\\[\]\\|\"/-]{1,255}$/;  // eslint-disable-line
             const [pluginId, region, resourceId] = parts;

--- a/postprocess/suppress.spec.js
+++ b/postprocess/suppress.spec.js
@@ -8,8 +8,8 @@ describe('create', function () {
     });
 
     it('should return the filter if matches', function () {
-        var filter = suppress.create(['plugin123:us-east-1:n*']);
-        expect(filter('plugin123:us-east-1:name')).to.equal('plugin123:us-east-1:n*');
+        var filter = suppress.create(['p*:us-east-1:n*']);
+        expect(filter('plugin123:us-east-1:name')).to.equal('p*:us-east-1:n*');
     });
 
     it('should return the filter if matches whole word', function () {


### PR DESCRIPTION
This PR restores the ability to use wildcards in `pluginId`, which was removed in #2125.

fixes #2127