### PR TITLE
Update Node.js version and entrypoint command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.12
+FROM node:lts-alpine3.22
 
 # Define a build argment that can be supplied when building the container
 # You can then do the following:
@@ -34,5 +34,5 @@ USER cloudsploit
 # command line arguments to the run command to control how this executes.
 # Thus, you can use the parameters that you would normally give to index.js
 # when running in a container.
-ENTRYPOINT ["cloudsploitscan"]
+ENTRYPOINT ["cloudsploit-scan"]
 CMD []


### PR DESCRIPTION
Updated the Dockerfile to use a newer Node.js base image and fixed the CLI entrypoint.
Builds cleanly with no "EBADENGINE" warnings, and
docker run cmd works as expected.
<img width="2447" height="1386" alt="image" src="https://github.com/user-attachments/assets/ab67cdc7-8d9f-4741-a997-4de0d077ded2" />
