### PR TITLE
feat(azure): accept pre-minted access tokens for federated identity /OIDC

### DIFF
--- a/helpers/azure/auth.js
+++ b/helpers/azure/auth.js
@@ -32,6 +32,25 @@ function reduceProperties(service, collection) {
 
 module.exports = {
     login: function(azureConfig, callback) {
+        // Pre-minted bearer-token shortcut. Allows callers that already hold
+        // valid ARM / Microsoft Graph / Key Vault access tokens (for example
+        // federated workload-identity / OIDC scenarios where no client
+        // secret is available) to bypass the ClientSecretCredential exchange
+        // and inject tokens directly. The three audiences map 1:1 to the
+        // {token, graphToken, vaultToken} contract that plugins already
+        // consume, so no plugin changes are required.
+        if (azureConfig.AccessTokens) {
+            var preMintedEnv = azureConfig.Govcloud
+                ? { name: 'AzureUSGovernment', portalUrl: 'https://portal.azure.us' }
+                : { name: 'AzureCloud',        portalUrl: 'https://portal.azure.com' };
+            return callback(null, {
+                environment: preMintedEnv,
+                token:       azureConfig.AccessTokens.arm,
+                graphToken:  azureConfig.AccessTokens.graph,
+                vaultToken:  azureConfig.AccessTokens.vault,
+            });
+        }
+
         if (!azureConfig.ApplicationID) return callback('No ApplicationID provided');
         if (!azureConfig.KeyValue) return callback('No KeyValue provided');
         if (!azureConfig.DirectoryID) return callback('No DirectoryID provided');

--- a/index.js
+++ b/index.js
@@ -155,6 +155,23 @@ if (config.credentials.aws.credential_file && (!settings.cloud || (settings.clou
         process.exit(1);
     }
     cloudConfig.location = 'East US';
+} else if (config.credentials.azure.AccessTokens && (!settings.cloud || (settings.cloud == 'azure'))) {
+    // Pre-minted bearer-token path. Pairs with the shortcut in
+    // helpers/azure/auth.js login() — callers that already hold valid
+    // ARM / Microsoft Graph / Key Vault tokens (for example federated
+    // workload-identity / OIDC scenarios where no client secret is
+    // available) supply AccessTokens directly instead of application_id /
+    // key_value. Tenant + subscription are still required so plugins can
+    // address the correct directory and subscription.
+    settings.cloud = 'azure';
+    checkRequiredKeys(config.credentials.azure, ['directory_id', 'subscription_id']);
+    cloudConfig = {
+        DirectoryID: config.credentials.azure.directory_id,
+        SubscriptionID: config.credentials.azure.subscription_id,
+        Govcloud: config.credentials.azure.govcloud,
+        AccessTokens: config.credentials.azure.AccessTokens,
+        location: 'East US',
+    };
 } else if (config.credentials.azure.application_id && (!settings.cloud || (settings.cloud == 'azure'))) {
     settings.cloud = 'azure';
     checkRequiredKeys(config.credentials.azure, ['key_value', 'directory_id', 'subscription_id']);


### PR DESCRIPTION
 ## Motivation

 CloudSploit currently authenticates to Azure via `ClientSecretCredential` only — `config.credentials.azure.application_id` + `key_value` are required by both `index.js` (config parsing) and `helpers/azure/auth.js` (`login()`). This
   blocks adoption in environments where no client secret exists, most notably:

  - **Federated workload identity / OIDC** — where Azure issues short-lived tokens via the SDK's `ClientAssertionCredential` rather than a static secret.
  - **Managed identity** scenarios where callers already hold a valid bearer.

  These callers can mint the three audience-specific tokens that CloudSploit's plugins already consume, but there's currently no way to inject them.

 ## Change
  
  Strictly-additive support for a new `AccessTokens` config field that accepts a pre-minted trio:

  ```js
  module.exports = {
      credentials: {
          azure: {
              directory_id:    '...',
              subscription_id: '...',                                                                                                                                                   
              govcloud:        false,           // optional
              AccessTokens: {
                  arm:   '...', // https://management.azure.com/.default
                  graph: '...', // https://graph.microsoft.com/.default
                  vault: '...', // https://vault.azure.net/.default
              },
          },
      },
  };

  Two files modified:

  - index.js — new else if branch detects config.credentials.azure.AccessTokens during config parsing and builds cloudConfig from directory_id + subscription_id + the token trio. Placed before the existing application_id branch so
  opt-in callers win when both are present.
  - helpers/azure/auth.js — login() short-circuits when azureConfig.AccessTokens is present, returning the tokens directly via the same {token, graphToken, vaultToken} contract that plugins already consume. No plugin changes
  required.

  Govcloud branch handled — Govcloud: true flips the environment.name/portalUrl to AzureUSGovernment/https://portal.azure.us, matching the existing govcloud return.

  Backward compatibility

  Zero impact on existing users:
  
  - The new AccessTokens field is opt-in. Configs that don't set it continue down the existing ClientSecretCredential path unchanged.
  - No plugin changes — token routing per audience was already in place upstream.
  - No new dependencies.

  36 insertions, 0 deletions.

  Testing
  
  Tested locally against a real Azure subscription using tokens minted from @azure/identity's ClientAssertionCredential (federated OIDC trust). Two subscriptions, both commercial cloud, full posture scan completes with the same
  finding distribution as a parallel ClientSecretCredential scan on the same subscription.