### PR TITLE
feat(google): accept pre-minted access tokens for service-account impersonation / OIDC

### DIFF
--- a/helpers/google/index.js
+++ b/helpers/google/index.js
@@ -2,7 +2,7 @@ var shared        = require(__dirname + '/../shared.js');
 var functions     = require('./functions.js');
 var regRegions    = require('./regions.js');
 
-const {JWT}       = require('google-auth-library');
+const {JWT, OAuth2Client} = require('google-auth-library');
 
 var async         = require('async');
 
@@ -11,6 +11,19 @@ var regions = function() {
 };
 
 var authenticate = async function(GoogleConfig) {
+    // Pre-minted access-token shortcut. Allows callers that already hold a
+    // valid Google Cloud access token (for example service-account
+    // impersonation, workload-identity federation, or OIDC flows where no
+    // service-account JSON key is available) to bypass the JWT exchange
+    // and inject the token directly. The returned OAuth2Client exposes
+    // the same .request() surface that plugins consume, so no plugin
+    // changes are required.
+    if (GoogleConfig.access_token) {
+        const client = new OAuth2Client();
+        client.setCredentials({ access_token: GoogleConfig.access_token });
+        return client;
+    }
+
     const client = new JWT({
         email: GoogleConfig.client_email,
         key: GoogleConfig.private_key,

--- a/index.js
+++ b/index.js
@@ -172,6 +172,21 @@ if (config.credentials.aws.credential_file && (!settings.cloud || (settings.clou
     settings.cloud = 'google';
     cloudConfig = loadHelperFile(config.credentials.google.credential_file);
     cloudConfig.project = cloudConfig.project_id;
+} else if (config.credentials.google.access_token && (!settings.cloud || (settings.cloud == 'google'))) {
+    // Pre-minted access-token path. Pairs with the shortcut in
+    // helpers/google/index.js authenticate() — callers that already hold
+    // a valid Google Cloud access token (for example service-account
+    // impersonation, workload-identity federation, or OIDC flows where
+    // no service-account JSON key is available) supply access_token
+    // directly instead of client_email / private_key. Project is still
+    // required so plugins can address the correct GCP project.
+    settings.cloud = 'google';
+    checkRequiredKeys(config.credentials.google, ['project']);
+    cloudConfig = {
+        type: 'service_account',
+        project: config.credentials.google.project,
+        access_token: config.credentials.google.access_token,
+    };
 } else if (config.credentials.google.project && (!settings.cloud || (settings.cloud == 'google'))) {
     settings.cloud = 'google';
     checkRequiredKeys(config.credentials.google, ['client_email', 'private_key']);


### PR DESCRIPTION
## Summary

  Adds a pre-minted access-token path to the GCP authentication flow so callers that already hold a valid Google Cloud OAuth2 access token can bypass the JWT-from-private-key exchange and inject the token directly.

  Mirrors the existing pattern added for Azure in #<your-azure-pr-number> (`feat(azure): accept pre-minted access tokens for federated identity / OIDC`).

  ## Why
  
  There are several legitimate scenarios where a caller has a valid Google Cloud access token but no service-account JSON key:

  - **Service-account impersonation** via `iamcredentials.generateAccessToken` — the orchestrator holds an executor SA and mints short-lived tokens against target SAs.
  - **Workload-identity federation** — federated identity exchanges return access tokens, never private keys.
  - **OIDC flows** — same as above, no client_secret available.

  Today these callers must either embed a long-lived private key (defeating the purpose of impersonation/federation) or fork/vendor patches against CloudSploit.

  ## What changed

  - `helpers/google/index.js` `authenticate()`: when `GoogleConfig.access_token` is present, return an `OAuth2Client` with the token set directly via `setCredentials({ access_token })`. The returned client exposes the same
  `.request()` surface that plugins consume — no plugin changes required.
  - `index.js`: new `else if` branch detecting `config.credentials.google.access_token` and configuring `cloudConfig` with `{ type, project, access_token }`. Placed ahead of the existing `client_email + private_key` branch so the
  pre-minted path takes precedence when a token is supplied. `project` is still required so plugins can address the correct GCP project.

  ## Test plan
  
  - [X] Existing direct-SA path (`client_email + private_key`) continues to work unchanged.
  - [X] New `access_token` path authenticates plugin API calls successfully.
  - [X] Omitting `project` produces a clear "missing required key" error.
  - [X] `credential_file` path remains unaffected (it's still evaluated first).